### PR TITLE
Update OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,7 +1,19 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - andrewsykim
-  - alejandrox1
-  - BenTheElder
-  - spiffxp
+- andrewsykim
+- BenTheElder
+- spiffxp
+- vladimirvivien
+reviewers:
+- andrewsykim
+- BenTheElder
+- cpanato
+- spiffxp
+- vladimirvivien
+
+emeritus_approvers:
+- alejandrox1
+
+labels:
+- sig/testing


### PR DESCRIPTION
Specifically:

- add vladimirvivien to approvers (prinicpal author)
- add cpanato to reviewers (has contributed PRs to this repo)
- move alejandrox1 to emeritus_approvers (has moved on from the project)
- dupe approvers as reviewers (except SIG chairs, we are here to unblock
  but can't guarantee bandwidth to review)
- add sig/testing label

Longer term:

- It's not clear to me whether andrewsykim is involved with this
  subproject, please move to emeritus if that's the case. I left as-is
  because they were active in kubernetes/kubernetes as of 5 days ago
- Please add some more folks to reviewers to start the clock on
  promoting to approvers. We want to ensure this doesn't turn into a
  de-facto mono-approver subproject

/cc @andrewsykim @alejandrox1 @vladimirvivien @BenTheElder @cpanato 