### PR TITLE
Fixed typo error in function name

### DIFF
--- a/pkg/conf/config_test.go
+++ b/pkg/conf/config_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestConfig_UseRESTConfig(t *testing.T) {
-	cfg := New().WithConfig(&rest.Config{})
+	cfg := New().WithKubeConfig(&rest.Config{})
 	if cfg.kubecfg == nil {
 		t.Errorf("kubecfg is nil")
 	}
@@ -32,7 +32,7 @@ func TestConfig_UseRESTConfig(t *testing.T) {
 func TestConfig_UseNamespace(t *testing.T) {
 	cfg := New().WithNamespace("testns")
 
-	if cfg.namespace != "testns"{
+	if cfg.namespace != "testns" {
 		t.Errorf("unexpected config namespace: %s", cfg.namespace)
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
There is a misspelling of function name. This patch fixes it.

#### Which issue(s) this PR fixes:
Fixes #11 

