### PR TITLE
Rename Res method to Resource

### DIFF
--- a/klient/k8s/resources/main_test.go
+++ b/klient/k8s/resources/main_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package res
+package resources
 
 import (
 	"context"

--- a/klient/k8s/resources/resources.go
+++ b/klient/k8s/resources/resources.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package res
+package resources
 
 import (
 	"context"
@@ -41,21 +41,22 @@ type Resources struct {
 	client cr.Client
 }
 
-// Res instantiates the controller runtime client
+// New instantiates the controller runtime client
 // object. User can get panic for belopw scenarios.
 // 1. if user does not provide k8s config
 // 2. if controller runtime client instantiation fails.
-func Res(cfg *rest.Config) *Resources {
+func New(cfg *rest.Config) (*Resources, error) {
 	if cfg == nil {
 		// TODO: logging
 		fmt.Println("must provide rest.Config")
-		panic(errors.New("must provide rest.Config"))
+		return nil, errors.New("must provide rest.Config")
 	}
 
 	cl, err := cr.New(cfg, cr.Options{Scheme: scheme.Scheme})
 	if err != nil {
 		// TODO: log error
-		panic(err)
+		fmt.Println("unexpected error creating client using provided config and client options")
+		return nil, err
 	}
 
 	res := &Resources{
@@ -64,7 +65,7 @@ func Res(cfg *rest.Config) *Resources {
 		client: cl,
 	}
 
-	return res
+	return res, nil
 }
 
 func (r *Resources) Get(ctx context.Context, name, namespace string, obj k8s.Object) error {

--- a/klient/k8s/resources/resources_test.go
+++ b/klient/k8s/resources/resources_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package res
+package resources
 
 import (
 	"context"
@@ -28,13 +28,13 @@ import (
 )
 
 func TestCreate(t *testing.T) {
-	res := Res(cfg)
-	if res == nil {
+	res, err := New(cfg)
+	if err != nil {
 		t.Errorf("config is nil")
 	}
 
 	// create a namespace
-	err := res.Create(context.TODO(), namespace)
+	err = res.Create(context.TODO(), namespace)
 	if err != nil {
 		t.Error("error while creating namespace", err)
 	}
@@ -51,12 +51,12 @@ func TestCreate(t *testing.T) {
 }
 
 func TestRes(t *testing.T) {
-	res := Res(cfg)
-	if res == nil {
+	res, err := New(cfg)
+	if err != nil {
 		t.Errorf("config is nil")
 	}
 
-	err := res.Create(context.TODO(), dep)
+	err = res.Create(context.TODO(), dep)
 	if err != nil {
 		t.Error("error while creating deployment", err)
 	}
@@ -82,38 +82,32 @@ func TestRes(t *testing.T) {
 }
 
 func TestResNoConfig(t *testing.T) {
-	defer func() {
-		if r := recover(); r == nil {
-			t.Error("expected panic while invoking Res without k8s config")
-		}
-	}()
-
-	Res(nil)
+	_, err := New(nil)
+	if err == nil {
+		t.Error("expected error while invoking Res without k8s config")
+	}
 }
 
 func TestResInvalidConfig(t *testing.T) {
-	defer func() {
-		if r := recover(); r == nil {
-			t.Error("expected panic while invoking Res with invalid k8s config")
-		}
-	}()
-
 	cfg := &rest.Config{
 		Host: "invalid-host",
 	}
 
-	Res(cfg)
+	_, err := New(cfg)
+	if err == nil {
+		t.Error("expected panic while invoking Res with invalid k8s config")
+	}
 }
 
 func TestUpdate(t *testing.T) {
-	res := Res(cfg)
-	if res == nil {
+	res, err := New(cfg)
+	if err != nil {
 		t.Errorf("config is nil")
 	}
 
 	depActual := getDeployment("update-test-dep-name")
 
-	err := res.Create(context.TODO(), depActual)
+	err = res.Create(context.TODO(), depActual)
 	if err != nil {
 		t.Error("error while creating deployment", err)
 	}
@@ -141,14 +135,14 @@ func TestUpdate(t *testing.T) {
 }
 
 func TestDelete(t *testing.T) {
-	res := Res(cfg)
-	if res == nil {
+	res, err := New(cfg)
+	if err != nil {
 		t.Errorf("config is nil")
 	}
 
 	depActual := getDeployment("delete-test-dep-name")
 
-	err := res.Create(context.TODO(), depActual)
+	err = res.Create(context.TODO(), depActual)
 	if err != nil {
 		t.Error("error while creating deployment", err)
 	}
@@ -160,13 +154,13 @@ func TestDelete(t *testing.T) {
 }
 
 func TestList(t *testing.T) {
-	res := Res(cfg)
-	if res == nil {
+	res, err := New(cfg)
+	if err != nil {
 		t.Errorf("config is nill")
 	}
 
 	deps := &appsv1.DeploymentList{}
-	err := res.List(context.TODO(), deps)
+	err = res.List(context.TODO(), deps)
 	if err != nil {
 		t.Error("error while getting the deployment", err)
 	}


### PR DESCRIPTION
This PR renames Res method under klient/k8s to Resource.

This was suggested by @andrewsykim as part of review comments [here](https://github.com/kubernetes-sigs/e2e-framework/pull/26#discussion_r664695191)

/cc @ShwethaKumbla 