### PR TITLE
Add a envconfig.Config method to inject a client from kubeconfig file

### DIFF
--- a/examples/k8s/main_test.go
+++ b/examples/k8s/main_test.go
@@ -23,7 +23,6 @@ import (
 	"testing"
 	"time"
 
-	"sigs.k8s.io/e2e-framework/klient"
 	"sigs.k8s.io/e2e-framework/pkg/env"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 )
@@ -51,12 +50,10 @@ func TestMain(m *testing.M) {
 		// env func: creates a klient.Client for the envconfig.Config
 		func(ctx context.Context, cfg *envconf.Config) (context.Context, error) {
 			kubecfg := ctx.Value(1).(string)
-			// create a klient.Client and set it for the env config
-			client, err := klient.NewWithKubeConfigFile(kubecfg)
+			_, err := cfg.WithKubeconfigFile(kubecfg) // set client in envconfig
 			if err != nil {
 				return ctx, fmt.Errorf("create klient.Client: %w", err)
 			}
-			cfg.WithClient(client) // set client in envconfig
 			return ctx, nil
 		},
 	).Finish(

--- a/pkg/envconf/config.go
+++ b/pkg/envconf/config.go
@@ -86,6 +86,16 @@ func NewFromFlags() (*Config, error) {
 	return e, nil
 }
 
+// WithKubeconfigFile creates a new klient.Client and injects it in the cfg
+func (c *Config) WithKubeconfigFile(kubecfg string) (*Config, error) {
+	client, err := klient.NewWithKubeConfigFile(kubecfg)
+	if err != nil {
+		return nil, err
+	}
+	c.client = client
+	return c, nil
+}
+
 // WithClient used to update the environment klient.Client
 func (c *Config) WithClient(client klient.Client) *Config {
 	c.client = client


### PR DESCRIPTION
This commit fixes #39 