### PR TITLE
K8s exeample updated with kind support package

### DIFF
--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -37,5 +37,5 @@ REPO_ROOT=$(git rev-parse --show-toplevel)
 cd "${REPO_ROOT}"
 
 # not testing the examples right now
-GO111MODULE=on go test -v -timeout="${TEST_TIMEOUT}s" -count=1 -cover -coverprofile coverage.out $(go list ./... | grep -v sigs.k8s.io/e2e-framework/examples)
+GO111MODULE=on go test -v -timeout="${TEST_TIMEOUT}s" -count=1 -cover -coverprofile coverage.out $(go list ./...)
 go tool cover -html coverage.out -o coverage.html

--- a/support/kind/kind.go
+++ b/support/kind/kind.go
@@ -79,13 +79,21 @@ func (k *Cluster) Create() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("kind kubeconfig file: %w", err)
 	}
-
 	defer file.Close()
+
+	k.kubecfgFile = file.Name()
+
 	if n, err := io.Copy(file, p.Out()); n == 0 || err != nil {
 		return "", fmt.Errorf("kind kubecfg file: bytes copied: %d: %w]", n, err)
 	}
 
 	return file.Name(), nil
+}
+
+// GetKubeconfig returns the path of the kubeconfig file
+// associated with this kind cluster
+func (k *Cluster) GetKubeconfig() string {
+	return k.kubecfgFile
 }
 
 func (k *Cluster) GetKubeCtlContext() string {


### PR DESCRIPTION
The examples/k8s source code has been updated in this patch
to use the support/kind package which provides a type to
stand up and run kind clusters. Useful during tests.