### PR TITLE
Add more info for before/after hooks

### DIFF
--- a/examples/every_test_custom_ns/README.md
+++ b/examples/every_test_custom_ns/README.md
@@ -1,0 +1,55 @@
+# Custom Namespaces For Every Test
+
+This example shows you how to use the env hooks in order to set up
+a custom namespace for every test. This could easily be done for every
+feature as well if that is your preference.
+
+First, you'll have to set up the env. In this example we assume an in-cluster configuration.
+```go
+var testenv env.Environment
+
+func TestMain(m *testing.M) {
+	testenv = env.New()
+	...
+}
+```
+Second, set the BeforeEachTest hook to create the namespace. We store it in the
+context so that it can be looked up on a per-test basis for deletion.
+```go
+testenv.BeforeEachTest(func(ctx context.Context, cfg *envconf.Config, t *testing.T) (context.Context, error) {
+    return createNSForTest(ctx,cfg,t,runID)
+})
+...
+// The creation uses the typical c.Resources() object.
+cfg.Client().Resources().Create(ctx,&nsObj)
+```
+Third, set the AfterEachTest hook to lookup and delete the namespace.
+```go
+testenv.AfterEachTest(func(ctx context.Context, cfg *envconf.Config, t *testing.T) (context.Context, error) {
+    return deleteNSForTest(ctx,cfg,t,runID)
+})
+...
+// The deletion uses the typical c.Resources() object.
+cfg.Client().Resources().Delete(ctx,&nsObj)
+```
+
+So, tying it all together, the `TestMain` looks like this:
+```go
+func TestMain(m *testing.M) {
+	testenv = env.New()
+
+	// Specifying a run ID so that multiple runs wouldn't collide.
+	runID := envconf.RandomName("", 4)
+
+	/* Skipping cluster creation for brevity */
+	
+	testenv.BeforeEachTest(func(ctx context.Context, cfg *envconf.Config, t *testing.T) (context.Context, error) {
+		return createNSForTest(ctx, cfg, t, runID)
+	})
+	testenv.AfterEachTest(func(ctx context.Context, cfg *envconf.Config, t *testing.T) (context.Context, error) {
+		return deleteNSForTest(ctx, cfg, t, runID)
+	})
+
+	os.Exit(testenv.Run(m))
+}
+```

--- a/examples/every_test_custom_ns/k8s_test.go
+++ b/examples/every_test_custom_ns/k8s_test.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package every_test_custom_ns
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+)
+
+func TestListPods(t *testing.T) {
+	f := features.New("pod list").
+		Assess("pods from kube-system", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			var pods corev1.PodList
+			err := cfg.Client().Resources("kube-system").List(context.TODO(), &pods)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Logf("found %d pods", len(pods.Items))
+			if len(pods.Items) == 0 {
+				t.Fatal("no pods in namespace kube-system")
+			}
+			return ctx
+		})
+
+	testenv.Test(t, f.Feature())
+}

--- a/examples/every_test_custom_ns/main_test.go
+++ b/examples/every_test_custom_ns/main_test.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package every_test_custom_ns
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/e2e-framework/pkg/env"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/support/kind"
+)
+
+var testenv env.Environment
+
+func TestMain(m *testing.M) {
+	testenv = env.New()
+
+	// Specifying a run ID so that multiple runs wouldn't collide.
+	runID := envconf.RandomName("ns", 4)
+
+	testenv.Setup(
+		// Step: creates kind cluster, propagate kind cluster object
+		func(ctx context.Context, cfg *envconf.Config) (context.Context, error) {
+			name := envconf.RandomName("my-cluster", 16)
+			cluster := kind.NewCluster(name)
+			kubeconfig, err := cluster.Create()
+			if err != nil {
+				return ctx, err
+			}
+			// stall a bit to allow most pods to come up
+			time.Sleep(time.Second * 10)
+
+			// update environment with kubecofig file
+			cfg.WithKubeconfigFile(kubeconfig)
+
+			// propagate cluster value
+			return context.WithValue(ctx, "cluster", cluster), nil
+		}).Finish(
+		// Teardown func: delete kind cluster
+		func(ctx context.Context, cfg *envconf.Config) (context.Context, error) {
+			cluster := ctx.Value("cluster").(*kind.Cluster) // nil should be tested
+			if err := cluster.Destroy(); err != nil {
+				return ctx, err
+			}
+			return ctx, nil
+		},
+	)
+
+	testenv.BeforeEachTest(func(ctx context.Context, cfg *envconf.Config, t *testing.T) (context.Context, error) {
+		return createNSForTest(ctx, cfg, t, runID)
+	})
+	testenv.AfterEachTest(func(ctx context.Context, cfg *envconf.Config, t *testing.T) (context.Context, error) {
+		return deleteNSForTest(ctx, cfg, t, runID)
+	})
+
+	os.Exit(testenv.Run(m))
+}
+
+// CreateNSForTest creates a random namespace with the runID as a prefix. It is stored in the context
+// so that the deleteNSForTest routine can look it up and delete it.
+func createNSForTest(ctx context.Context, cfg *envconf.Config, t *testing.T, runID string) (context.Context, error) {
+	ns := envconf.RandomName(runID, 10)
+	ctx = context.WithValue(ctx, nsKey(t), ns)
+
+	t.Logf("Creating NS %v for test %v", ns, t.Name())
+	nsObj := v1.Namespace{}
+	nsObj.Name = ns
+	return ctx, cfg.Client().Resources().Create(ctx, &nsObj)
+}
+
+// DeleteNSForTest looks up the namespace corresponding to the given test and deletes it.
+func deleteNSForTest(ctx context.Context, cfg *envconf.Config, t *testing.T, runID string) (context.Context, error) {
+	ns := fmt.Sprint(ctx.Value(nsKey(t)))
+	t.Logf("Deleting NS %v for test %v", ns, t.Name())
+
+	nsObj := v1.Namespace{}
+	nsObj.Name = ns
+	return ctx, cfg.Client().Resources().Delete(ctx, &nsObj)
+}
+
+func nsKey(t *testing.T) string {
+	return "NS-for-%v" + t.Name()
+}

--- a/examples/predefined_env_funcs/main_test.go
+++ b/examples/predefined_env_funcs/main_test.go
@@ -39,6 +39,8 @@ func TestMain(m *testing.M) {
 		envfuncs.CreateNamespace(namespace),
 	)
 
+	testenv.BeforeEachTest()
+
 	// Finish uses pre-defined funcs to
 	// remove namespace, then delete cluster
 	testenv.Finish(

--- a/pkg/env/action.go
+++ b/pkg/env/action.go
@@ -18,6 +18,8 @@ package env
 
 import (
 	"context"
+	"fmt"
+	"testing"
 
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/internal/types"
@@ -34,11 +36,62 @@ const (
 
 // action a group env functions
 type action struct {
-	role  actionRole
+	role actionRole
+
+	// funcs store the EnvFuncs used for setup/finish and before/after test.
 	funcs []types.EnvFunc
+
+	// featureFuncs store the FeatureEnvFunc for before/after feature.
+	featureFuncs []types.FeatureEnvFunc
+
+	// testFuncs store the TestEnvFunc for before/after feature.
+	testFuncs []types.TestEnvFunc
 }
 
-func (a action) run(ctx context.Context, cfg *envconf.Config) (context.Context, error) {
+// runWithT will run the action and inject *testing.T into the callback function.
+func (a *action) runWithT(ctx context.Context, cfg *envconf.Config, t *testing.T) (context.Context, error) {
+	switch a.role {
+	case roleBeforeTest, roleAfterTest:
+		for _, f := range a.testFuncs {
+			if f == nil {
+				continue
+			}
+
+			var err error
+			ctx, err = f(ctx, cfg, t)
+			if err != nil {
+				return ctx, err
+			}
+		}
+	default:
+		return ctx, fmt.Errorf("runWithT() is only valid for actions roleBeforeTest and roleAfterTest")
+	}
+
+	return ctx, nil
+}
+
+// runWithFeature will run the action and inject a FeatureInfo object into the callback function.
+func (a *action) runWithFeature(ctx context.Context, cfg *envconf.Config, fi types.FeatureInfo) (context.Context, error) {
+	switch a.role {
+	case roleBeforeFeature, roleAfterFeature:
+		for _, f := range a.featureFuncs {
+			if f == nil {
+				continue
+			}
+
+			var err error
+			ctx, err = f(ctx, cfg, fi)
+			if err != nil {
+				return ctx, err
+			}
+		}
+	default:
+		return ctx, fmt.Errorf("runWithFeature() is only valid for actions roleBeforeFeature and roleAfterFeature")
+	}
+	return ctx, nil
+}
+
+func (a *action) run(ctx context.Context, cfg *envconf.Config) (context.Context, error) {
 	for _, f := range a.funcs {
 		if f == nil {
 			continue

--- a/pkg/env/action_test.go
+++ b/pkg/env/action_test.go
@@ -43,7 +43,7 @@ func TestAction_Run(t *testing.T) {
 						return ctx, nil
 					},
 				}
-				_, err = action{role: roleSetup, funcs: funcs}.run(ctx, cfg)
+				_, err = (&action{role: roleSetup, funcs: funcs}).run(ctx, cfg)
 				return
 			},
 			expected: 12,
@@ -62,7 +62,7 @@ func TestAction_Run(t *testing.T) {
 						return ctx, nil
 					},
 				}
-				_, err = action{role: roleSetup, funcs: funcs}.run(ctx, cfg)
+				_, err = (&action{role: roleSetup, funcs: funcs}).run(ctx, cfg)
 				return
 			},
 			expected: 24,
@@ -82,7 +82,7 @@ func TestAction_Run(t *testing.T) {
 						return ctx, nil
 					},
 				}
-				_, err = action{role: roleSetup, funcs: funcs}.run(ctx, cfg)
+				_, err = (&action{role: roleSetup, funcs: funcs}).run(ctx, cfg)
 				return
 			},
 			expected: 6,

--- a/pkg/env/env_test.go
+++ b/pkg/env/env_test.go
@@ -22,6 +22,7 @@ import (
 
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
+	"sigs.k8s.io/e2e-framework/pkg/internal/types"
 )
 
 func TestEnv_New(t *testing.T) {
@@ -69,7 +70,7 @@ func TestEnv_APIMethods(t *testing.T) {
 			name: "before actions",
 			setup: func(t *testing.T) *testEnv {
 				env := newTestEnv()
-				env.BeforeEachTest(func(ctx context.Context, _ *envconf.Config) (context.Context, error) {
+				env.BeforeEachTest(func(ctx context.Context, _ *envconf.Config, t *testing.T) (context.Context, error) {
 					return ctx, nil
 				})
 				return env
@@ -80,7 +81,7 @@ func TestEnv_APIMethods(t *testing.T) {
 			name: "after actions",
 			setup: func(t *testing.T) *testEnv {
 				env := newTestEnv()
-				env.AfterEachTest(func(ctx context.Context, _ *envconf.Config) (context.Context, error) {
+				env.AfterEachTest(func(ctx context.Context, _ *envconf.Config, t *testing.T) (context.Context, error) {
 					return ctx, nil
 				})
 				return env
@@ -104,9 +105,9 @@ func TestEnv_APIMethods(t *testing.T) {
 				env := newTestEnv()
 				env.Setup(func(ctx context.Context, _ *envconf.Config) (context.Context, error) {
 					return ctx, nil
-				}).BeforeEachTest(func(ctx context.Context, _ *envconf.Config) (context.Context, error) {
+				}).BeforeEachTest(func(ctx context.Context, _ *envconf.Config, t *testing.T) (context.Context, error) {
 					return ctx, nil
-				}).AfterEachTest(func(ctx context.Context, _ *envconf.Config) (context.Context, error) {
+				}).AfterEachTest(func(ctx context.Context, _ *envconf.Config, t *testing.T) (context.Context, error) {
 					return ctx, nil
 				}).Finish(func(ctx context.Context, _ *envconf.Config) (context.Context, error) {
 					return ctx, nil
@@ -186,7 +187,7 @@ func TestEnv_Test(t *testing.T) {
 			},
 			setup: func(t *testing.T, ctx context.Context) (val []string) {
 				env := newTestEnv()
-				env.BeforeEachTest(func(ctx context.Context, _ *envconf.Config) (context.Context, error) {
+				env.BeforeEachTest(func(ctx context.Context, _ *envconf.Config, t *testing.T) (context.Context, error) {
 					val = append(val, "before-each-test")
 					return ctx, nil
 				})
@@ -208,10 +209,10 @@ func TestEnv_Test(t *testing.T) {
 			},
 			setup: func(t *testing.T, ctx context.Context) (val []string) {
 				env := newTestEnv()
-				env.AfterEachTest(func(ctx context.Context, _ *envconf.Config) (context.Context, error) {
+				env.AfterEachTest(func(ctx context.Context, _ *envconf.Config, t *testing.T) (context.Context, error) {
 					val = append(val, "after-each-test")
 					return ctx, nil
-				}).BeforeEachTest(func(ctx context.Context, _ *envconf.Config) (context.Context, error) {
+				}).BeforeEachTest(func(ctx context.Context, _ *envconf.Config, t *testing.T) (context.Context, error) {
 					val = append(val, "before-each-test")
 					return ctx, nil
 				})
@@ -232,7 +233,7 @@ func TestEnv_Test(t *testing.T) {
 			},
 			setup: func(t *testing.T, ctx context.Context) (val []string) {
 				env := newTestEnv()
-				env.AfterEachTest(func(ctx context.Context, _ *envconf.Config) (context.Context, error) {
+				env.AfterEachTest(func(ctx context.Context, _ *envconf.Config, t *testing.T) (context.Context, error) {
 					val = append(val, "after-each-test")
 					return ctx, nil
 				})
@@ -284,7 +285,7 @@ func TestEnv_Test(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				env.BeforeEachTest(func(ctx context.Context, _ *envconf.Config) (context.Context, error) {
+				env.BeforeEachTest(func(ctx context.Context, _ *envconf.Config, t *testing.T) (context.Context, error) {
 					// update before test
 					val, ok := ctx.Value(&ctxTestKeyString{}).([]string)
 					if !ok {
@@ -293,7 +294,7 @@ func TestEnv_Test(t *testing.T) {
 					val = append(val, "before-each-test")
 					return context.WithValue(ctx, &ctxTestKeyString{}, val), nil
 				})
-				env.AfterEachTest(func(ctx context.Context, _ *envconf.Config) (context.Context, error) {
+				env.AfterEachTest(func(ctx context.Context, _ *envconf.Config, t *testing.T) (context.Context, error) {
 					// update after the test
 					val, ok := ctx.Value(&ctxTestKeyString{}).([]string)
 					if !ok {
@@ -363,11 +364,11 @@ func TestEnv_Test(t *testing.T) {
 			setup: func(t *testing.T, ctx context.Context) (val []string) {
 				env := newTestEnv()
 				val = []string{}
-				env.BeforeEachTest(func(ctx context.Context, _ *envconf.Config) (context.Context, error) {
+				env.BeforeEachTest(func(ctx context.Context, _ *envconf.Config, t *testing.T) (context.Context, error) {
 					val = append(val, "before-each-test")
 					return ctx, nil
 				})
-				env.AfterEachTest(func(ctx context.Context, _ *envconf.Config) (context.Context, error) {
+				env.AfterEachTest(func(ctx context.Context, _ *envconf.Config, t *testing.T) (context.Context, error) {
 					val = append(val, "after-each-test")
 					return ctx, nil
 				})
@@ -397,10 +398,10 @@ func TestEnv_Test(t *testing.T) {
 			setup: func(t *testing.T, ctx context.Context) []string {
 				env := newTestEnv()
 				val := []string{}
-				env.BeforeEachFeature(func(ctx context.Context, _ *envconf.Config) (context.Context, error) {
+				env.BeforeEachFeature(func(ctx context.Context, _ *envconf.Config, info types.FeatureInfo) (context.Context, error) {
 					val = append(val, "before-each-feature")
 					return ctx, nil
-				}).AfterEachFeature(func(ctx context.Context, _ *envconf.Config) (context.Context, error) {
+				}).AfterEachFeature(func(ctx context.Context, _ *envconf.Config, info types.FeatureInfo) (context.Context, error) {
 					val = append(val, "after-each-feature")
 					return ctx, nil
 				})

--- a/pkg/env/main_test.go
+++ b/pkg/env/main_test.go
@@ -58,7 +58,7 @@ func TestMain(m *testing.M) {
 			val = append(val, "setup-2")
 			return context.WithValue(ctx, &ctxTestKeyString{}, val), nil
 		},
-	).BeforeEachTest(func(ctx context.Context, _ *envconf.Config) (context.Context, error) {
+	).BeforeEachTest(func(ctx context.Context, _ *envconf.Config, t *testing.T) (context.Context, error) {
 		// update before each test
 		val, ok := ctx.Value(&ctxTestKeyString{}).([]string)
 		if !ok {
@@ -66,7 +66,7 @@ func TestMain(m *testing.M) {
 		}
 		val = append(val, "before-each-test")
 		return context.WithValue(ctx, &ctxTestKeyString{}, val), nil
-	}).AfterEachTest(func(ctx context.Context, _ *envconf.Config) (context.Context, error) {
+	}).AfterEachTest(func(ctx context.Context, _ *envconf.Config, t *testing.T) (context.Context, error) {
 		// update after the test
 		val, ok := ctx.Value(&ctxTestKeyString{}).([]string)
 		if !ok {

--- a/pkg/internal/types/types.go
+++ b/pkg/internal/types/types.go
@@ -29,6 +29,18 @@ import (
 // to caller.
 type EnvFunc func(context.Context, *envconf.Config) (context.Context, error)
 
+// FeatureEnvFunc represents a user-defined operation that
+// can be used to customized the behavior of the
+// environment. Changes to context are expected to surface
+// to caller. Meant for use with before/after feature hooks.
+type FeatureEnvFunc func(context.Context, *envconf.Config, FeatureInfo) (context.Context, error)
+
+// TestEnvFunc represents a user-defined operation that
+// can be used to customized the behavior of the
+// environment. Changes to context are expected to surface
+// to caller. Meant for use with before/after test hooks.
+type TestEnvFunc func(context.Context, *envconf.Config, *testing.T) (context.Context, error)
+
 // Environment represents an environment where
 // features can be tested.
 type Environment interface {
@@ -41,15 +53,15 @@ type Environment interface {
 
 	// BeforeEachTest registers environment funcs that are executed
 	// before each Env.Test(...)
-	BeforeEachTest(...EnvFunc) Environment
+	BeforeEachTest(...TestEnvFunc) Environment
 
 	// BeforeEachFeature registers step functions that are executed
 	// before each Feature is tested during env.Test call.
-	BeforeEachFeature(...EnvFunc) Environment
+	BeforeEachFeature(...FeatureEnvFunc) Environment
 
 	// AfterEachFeature registers step functions that are executed
 	// after each feature is tested during an env.Test call.
-	AfterEachFeature(...EnvFunc) Environment
+	AfterEachFeature(...FeatureEnvFunc) Environment
 
 	// Test executes a test feature defined in a TestXXX function
 	// This method surfaces context for further updates.
@@ -57,7 +69,7 @@ type Environment interface {
 
 	// AfterEachTest registers environment funcs that are executed
 	// after each Env.Test(...).
-	AfterEachTest(...EnvFunc) Environment
+	AfterEachTest(...TestEnvFunc) Environment
 
 	// Finish registers funcs that are executed at the end of the
 	// test suite.
@@ -76,6 +88,12 @@ type Feature interface {
 	Labels() Labels
 	// Steps testing tasks to test the feature
 	Steps() []Step
+}
+
+type FeatureInfo struct {
+	Name   string
+	Labels map[string]string
+	Steps  []Step
 }
 
 type Level uint8


### PR DESCRIPTION
- Adds two different types of functions for actions to store/call
which take features and *testing.T objects
- This allows before/after hooks that can actually reference the
object in question
- This enables an extremely useful and common test case of creating
a namespace for each test
- The namespace-per-test use case is shown in a new example

Signed-off-by: John Schnake <jschnake@vmware.com>