### PR TITLE
Rework some unit test patterns

### DIFF
--- a/klient/k8s/resources/resources_test.go
+++ b/klient/k8s/resources/resources_test.go
@@ -33,7 +33,7 @@ import (
 func TestCreate(t *testing.T) {
 	res, err := New(cfg)
 	if err != nil {
-		t.Errorf("config is nil")
+		t.Fatalf("error creating new config: %v", err)
 	}
 
 	// create a namespace

--- a/pkg/env/action_test.go
+++ b/pkg/env/action_test.go
@@ -35,7 +35,7 @@ func TestAction_Run(t *testing.T) {
 	}{
 		{
 			name: "single-step action",
-			ctx:  context.WithValue(context.TODO(), &ctxTestKeyInt{}, 1),
+			ctx:  context.WithValue(context.TODO(), &ctxTestKeyString{}, 1),
 			setup: func(ctx context.Context, cfg *envconf.Config) (val int, err error) {
 				funcs := []types.EnvFunc{
 					func(ctx context.Context, cfg *envconf.Config) (context.Context, error) {
@@ -50,7 +50,7 @@ func TestAction_Run(t *testing.T) {
 		},
 		{
 			name: "multi-step action",
-			ctx:  context.WithValue(context.TODO(), &ctxTestKeyInt{}, 1),
+			ctx:  context.WithValue(context.TODO(), &ctxTestKeyString{}, 1),
 			setup: func(ctx context.Context, cfg *envconf.Config) (val int, err error) {
 				funcs := []types.EnvFunc{
 					func(ctx context.Context, cfg *envconf.Config) (context.Context, error) {
@@ -69,11 +69,11 @@ func TestAction_Run(t *testing.T) {
 		},
 		{
 			name: "read from context",
-			ctx:  context.WithValue(context.TODO(), &ctxTestKeyInt{}, 1),
+			ctx:  context.WithValue(context.TODO(), &ctxTestKeyString{}, 1),
 			setup: func(ctx context.Context, cfg *envconf.Config) (val int, err error) {
 				funcs := []types.EnvFunc{
 					func(ctx context.Context, cfg *envconf.Config) (context.Context, error) {
-						i := ctx.Value(&ctxTestKeyInt{}).(int) + 2
+						i := ctx.Value(&ctxTestKeyString{}).(int) + 2
 						val = i
 						return ctx, nil
 					},

--- a/pkg/env/env_test.go
+++ b/pkg/env/env_test.go
@@ -134,17 +134,19 @@ func TestEnv_Test(t *testing.T) {
 	tests := []struct {
 		name     string
 		ctx      context.Context
-		setup    func(*testing.T, context.Context) int
-		expected int
+		setup    func(*testing.T, context.Context) []string
+		expected []string
 	}{
 		{
-			name:     "feature only",
-			ctx:      context.TODO(),
-			expected: 42,
-			setup: func(t *testing.T, ctx context.Context) (val int) {
+			name: "feature only",
+			ctx:  context.TODO(),
+			expected: []string{
+				"test-feat",
+			},
+			setup: func(t *testing.T, ctx context.Context) (val []string) {
 				env := newTestEnv()
 				f := features.New("test-feat").Assess("assess", func(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
-					val = 42
+					val = append(val, "test-feat")
 					return ctx
 				})
 				env.Test(t, f.Feature())
@@ -152,20 +154,22 @@ func TestEnv_Test(t *testing.T) {
 			},
 		},
 		{
-			name:     "filtered feature",
-			ctx:      context.TODO(),
-			expected: 42,
-			setup: func(t *testing.T, ctx context.Context) (val int) {
+			name: "filtered feature",
+			ctx:  context.TODO(),
+			expected: []string{
+				"test-feat",
+			},
+			setup: func(t *testing.T, ctx context.Context) (val []string) {
 				env := NewWithConfig(envconf.New().WithFeatureRegex("test-feat"))
 				f := features.New("test-feat").Assess("assess", func(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
-					val = 42
+					val = append(val, "test-feat")
 					return ctx
 				})
 				env.Test(t, f.Feature())
 
 				env2 := NewWithConfig(envconf.New().WithFeatureRegex("skip-me"))
 				f2 := features.New("test-feat-2").Assess("assess", func(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
-					val = 42 + 1
+					val = append(val, "test-feat-2")
 					return ctx
 				})
 				env2.Test(t, f2.Feature())
@@ -174,17 +178,20 @@ func TestEnv_Test(t *testing.T) {
 			},
 		},
 		{
-			name:     "with before-test",
-			ctx:      context.TODO(),
-			expected: 86,
-			setup: func(t *testing.T, ctx context.Context) (val int) {
+			name: "with before-test",
+			ctx:  context.TODO(),
+			expected: []string{
+				"before-each-test",
+				"test-feat",
+			},
+			setup: func(t *testing.T, ctx context.Context) (val []string) {
 				env := newTestEnv()
 				env.BeforeEachTest(func(ctx context.Context, _ *envconf.Config) (context.Context, error) {
-					val = 44
+					val = append(val, "before-each-test")
 					return ctx, nil
 				})
 				f := features.New("test-feat").Assess("assess", func(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
-					val += 42
+					val = append(val, "test-feat")
 					return ctx
 				})
 				env.Test(t, f.Feature())
@@ -192,20 +199,24 @@ func TestEnv_Test(t *testing.T) {
 			},
 		},
 		{
-			name:     "with after-test",
-			ctx:      context.TODO(),
-			expected: 66,
-			setup: func(t *testing.T, ctx context.Context) (val int) {
+			name: "with after-test",
+			ctx:  context.TODO(),
+			expected: []string{
+				"before-each-test",
+				"test-feat",
+				"after-each-test",
+			},
+			setup: func(t *testing.T, ctx context.Context) (val []string) {
 				env := newTestEnv()
 				env.AfterEachTest(func(ctx context.Context, _ *envconf.Config) (context.Context, error) {
-					val -= 20
+					val = append(val, "after-each-test")
 					return ctx, nil
 				}).BeforeEachTest(func(ctx context.Context, _ *envconf.Config) (context.Context, error) {
-					val = 44
+					val = append(val, "before-each-test")
 					return ctx, nil
 				})
 				f := features.New("test-feat").Assess("assess", func(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
-					val += 42
+					val = append(val, "test-feat")
 					return ctx
 				})
 				env.Test(t, f.Feature())
@@ -213,17 +224,20 @@ func TestEnv_Test(t *testing.T) {
 			},
 		},
 		{
-			name:     "with before-after-test",
-			ctx:      context.TODO(),
-			expected: 44,
-			setup: func(t *testing.T, ctx context.Context) (val int) {
+			name: "with before-after-test",
+			ctx:  context.TODO(),
+			expected: []string{
+				"test-feat",
+				"after-each-test",
+			},
+			setup: func(t *testing.T, ctx context.Context) (val []string) {
 				env := newTestEnv()
 				env.AfterEachTest(func(ctx context.Context, _ *envconf.Config) (context.Context, error) {
-					val = 44
+					val = append(val, "after-each-test")
 					return ctx, nil
 				})
 				f := features.New("test-feat").Assess("assess", func(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
-					val = 42 + val
+					val = append(val, "test-feat")
 					return ctx
 				})
 				env.Test(t, f.Feature())
@@ -231,23 +245,26 @@ func TestEnv_Test(t *testing.T) {
 			},
 		},
 		{
-			name:     "filter assessment",
-			ctx:      context.TODO(),
-			expected: 45,
-			setup: func(t *testing.T, ctx context.Context) (val int) {
-				val = 42
+			name: "filter assessment",
+			ctx:  context.TODO(),
+			expected: []string{
+				"add-1",
+				"add-2",
+			},
+			setup: func(t *testing.T, ctx context.Context) (val []string) {
+				val = []string{}
 				env := NewWithConfig(envconf.New().WithAssessmentRegex("add-*"))
 				f := features.New("test-feat").
 					Assess("add-one", func(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
-						val++
+						val = append(val, "add-1")
 						return ctx
 					}).
 					Assess("add-two", func(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
-						val += 2
+						val = append(val, "add-2")
 						return ctx
 					}).
 					Assess("take-one", func(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
-						val--
+						val = append(val, "take-1")
 						return ctx
 					})
 				env.Test(t, f.Feature())
@@ -255,71 +272,78 @@ func TestEnv_Test(t *testing.T) {
 			},
 		},
 		{
-			name:     "context value propagation with before, during, and after test",
-			ctx:      context.TODO(),
-			expected: 48,
-			setup: func(t *testing.T, ctx context.Context) int {
-				env, err := NewWithContext(context.WithValue(ctx, &ctxTestKeyInt{}, 44), envconf.New())
+			name: "context value propagation with before, during, and after test",
+			ctx:  context.TODO(),
+			expected: []string{
+				"before-each-test",
+				"test-feat",
+				"after-each-test",
+			},
+			setup: func(t *testing.T, ctx context.Context) []string {
+				env, err := NewWithContext(context.WithValue(ctx, &ctxTestKeyString{}, []string{}), envconf.New())
 				if err != nil {
 					t.Fatal(err)
 				}
 				env.BeforeEachTest(func(ctx context.Context, _ *envconf.Config) (context.Context, error) {
 					// update before test
-					val, ok := ctx.Value(&ctxTestKeyInt{}).(int)
+					val, ok := ctx.Value(&ctxTestKeyString{}).([]string)
 					if !ok {
-						t.Fatal("context value was not int")
+						t.Fatal("context value was not []string")
 					}
-					val += 2 // 46
-					return context.WithValue(ctx, &ctxTestKeyInt{}, val), nil
+					val = append(val, "before-each-test")
+					return context.WithValue(ctx, &ctxTestKeyString{}, val), nil
 				})
 				env.AfterEachTest(func(ctx context.Context, _ *envconf.Config) (context.Context, error) {
 					// update after the test
-					val, ok := ctx.Value(&ctxTestKeyInt{}).(int)
+					val, ok := ctx.Value(&ctxTestKeyString{}).([]string)
 					if !ok {
-						t.Fatal("context value was not int")
+						t.Fatal("context value was not []string")
 					}
-					val++ // 48
-					return context.WithValue(ctx, &ctxTestKeyInt{}, val), nil
+					val = append(val, "after-each-test")
+					return context.WithValue(ctx, &ctxTestKeyString{}, val), nil
 				})
 				f := features.New("test-feat").Assess("assess", func(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
-					val, ok := ctx.Value(&ctxTestKeyInt{}).(int)
+					val, ok := ctx.Value(&ctxTestKeyString{}).([]string)
 					if !ok {
-						t.Fatal("context value was not int")
+						t.Fatal("context value was not []string")
 					}
-					val++ // 47
+					val = append(val, "test-feat")
 
-					return context.WithValue(ctx, &ctxTestKeyInt{}, val)
+					return context.WithValue(ctx, &ctxTestKeyString{}, val)
 				})
 
 				env.Test(t, f.Feature())
-				return env.(*testEnv).ctx.Value(&ctxTestKeyInt{}).(int)
+				return env.(*testEnv).ctx.Value(&ctxTestKeyString{}).([]string)
 			},
 		},
 		{
 			name:     "no features specified",
 			ctx:      context.TODO(),
-			expected: 0,
-			setup: func(t *testing.T, ctx context.Context) (val int) {
+			expected: []string{},
+			setup: func(t *testing.T, ctx context.Context) (val []string) {
 				env := newTestEnv()
 				env.Test(t)
 				return
 			},
 		},
 		{
-			name:     "multiple features",
-			ctx:      context.TODO(),
-			expected: 84,
-			setup: func(t *testing.T, ctx context.Context) (val int) {
+			name: "multiple features",
+			ctx:  context.TODO(),
+			expected: []string{
+				"test-feature-1",
+				"test-feature-2",
+			},
+			setup: func(t *testing.T, ctx context.Context) (val []string) {
 				env := newTestEnv()
 				f1 := features.New("test-feat-1").
 					Assess("assess", func(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
-						val = 42
+						val = append(val, "test-feature-1")
 						return ctx
 					})
 
 				f2 := features.New("test-feat-2").
 					Assess("assess", func(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
-						val += 42
+						val = append(val, "test-feature-2")
 						return ctx
 					})
 
@@ -328,63 +352,82 @@ func TestEnv_Test(t *testing.T) {
 			},
 		},
 		{
-			name:     "multiple features with before-after-test",
-			ctx:      context.TODO(),
-			expected: 66,
-			setup: func(t *testing.T, ctx context.Context) (val int) {
+			name: "multiple features with before-after-test",
+			ctx:  context.TODO(),
+			expected: []string{
+				"before-each-test",
+				"test-feat-1",
+				"test-feat-2",
+				"after-each-test",
+			},
+			setup: func(t *testing.T, ctx context.Context) (val []string) {
 				env := newTestEnv()
-				env.AfterEachTest(func(ctx context.Context, _ *envconf.Config) (context.Context, error) {
-					val = 0
+				val = []string{}
+				env.BeforeEachTest(func(ctx context.Context, _ *envconf.Config) (context.Context, error) {
+					val = append(val, "before-each-test")
 					return ctx, nil
 				})
 				env.AfterEachTest(func(ctx context.Context, _ *envconf.Config) (context.Context, error) {
-					val = 22 * 3
+					val = append(val, "after-each-test")
 					return ctx, nil
 				})
 				f1 := features.New("test-feat-1").Assess("assess", func(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
-					val = 42 + val
+					val = append(val, "test-feat-1")
 					return ctx
 				})
 				f2 := features.New("test-feat-2").Assess("assess", func(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
-					val = 42 - 40
+					val = append(val, "test-feat-2")
 					return ctx
 				})
 				env.Test(t, f1.Feature(), f2.Feature())
 				return
 			},
 		},
-
 		{
-			name:     "with before-and-after features",
-			ctx:      context.TODO(),
-			expected: 300,
-			setup: func(t *testing.T, ctx context.Context) (val int) {
+			name: "with before-and-after features",
+			ctx:  context.TODO(),
+			expected: []string{
+				"before-each-feature",
+				"test-feat-1",
+				"after-each-feature",
+				"before-each-feature",
+				"test-feat-2",
+				"after-each-feature",
+			},
+			setup: func(t *testing.T, ctx context.Context) []string {
 				env := newTestEnv()
+				val := []string{}
 				env.BeforeEachFeature(func(ctx context.Context, _ *envconf.Config) (context.Context, error) {
-					val += 20
+					val = append(val, "before-each-feature")
 					return ctx, nil
 				}).AfterEachFeature(func(ctx context.Context, _ *envconf.Config) (context.Context, error) {
-					val -= 20
+					val = append(val, "after-each-feature")
 					return ctx, nil
 				})
 				f1 := features.New("test-feat").Assess("assess", func(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
-					val *= 4
+					val = append(val, "test-feat-1")
 					return ctx
 				})
 				f2 := features.New("test-feat").Assess("assess", func(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
-					val *= 4
+					val = append(val, "test-feat-2")
 					return ctx
 				})
 				env.Test(t, f1.Feature(), f2.Feature())
-				return
+				return val
 			},
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			result := test.setup(t, test.ctx)
-			if result != test.expected {
-				t.Error("unexpected result: ", result)
+			if len(test.expected) != len(result) {
+				t.Fatalf("Expected:\n%v but got result:\n%v", test.expected, result)
+			}
+			for i := range test.expected {
+				if result[i] != test.expected[i] {
+					t.Errorf("Expected:\n%v but got result:\n%v", test.expected, result)
+					break
+				}
 			}
 		})
 	}
@@ -396,27 +439,34 @@ func TestEnv_Test(t *testing.T) {
 func TestEnv_Context_Propagation(t *testing.T) {
 	f := features.New("test-context-propagation").
 		Assess("assess", func(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
-			val, ok := ctx.Value(&ctxTestKeyInt{}).(int)
+			val, ok := ctx.Value(&ctxTestKeyString{}).([]string)
 			if !ok {
 				t.Fatal("context value was not int")
 			}
-			val += 10 // 100
-			return context.WithValue(ctx, &ctxTestKeyInt{}, val)
+			val = append(val, "test-context-propagation")
+			return context.WithValue(ctx, &ctxTestKeyString{}, val)
 		})
 
 	envForTesting.Test(t, f.Feature())
-	// after test will dec by 1
 
 	env, ok := envForTesting.(*testEnv)
 	if !ok {
 		t.Fatal("wrong type")
 	}
 
-	finalVal, ok := env.ctx.Value(&ctxTestKeyInt{}).(int)
+	finalVal, ok := env.ctx.Value(&ctxTestKeyString{}).([]string)
 	if !ok {
 		t.Fatal("wrong type")
 	}
-	if finalVal != 99 {
-		t.Fatalf("unexpected value %d", finalVal)
+
+	expected := []string{"setup-1", "setup-2", "before-each-test", "test-context-propagation", "after-each-test"}
+	if len(finalVal) != len(expected) {
+		t.Fatalf("Expected:\n%v but got result:\n%v", expected, finalVal)
+	}
+	for i := range finalVal {
+		if finalVal[i] != expected[i] {
+			t.Errorf("Expected:\n%v but got result:\n%v", expected, finalVal)
+			break
+		}
 	}
 }

--- a/pkg/env/main_test.go
+++ b/pkg/env/main_test.go
@@ -28,12 +28,12 @@ import (
 
 var envForTesting types.Environment
 
-type ctxTestKeyInt struct{}
+type ctxTestKeyString struct{}
 
 func TestMain(m *testing.M) {
 	// setup new environment test with injected context value
-	initialVal := 22
-	env, err := NewWithContext(context.WithValue(context.Background(), &ctxTestKeyInt{}, initialVal), envconf.New())
+	initialVal := []string{}
+	env, err := NewWithContext(context.WithValue(context.Background(), &ctxTestKeyString{}, initialVal), envconf.New())
 	if err != nil {
 		log.Fatalf("Test suite failed to start: %s", err)
 	}
@@ -43,37 +43,37 @@ func TestMain(m *testing.M) {
 	// each func will update value inside context
 	envForTesting.Setup(
 		func(ctx context.Context, _ *envconf.Config) (context.Context, error) {
-			val, ok := ctx.Value(&ctxTestKeyInt{}).(int)
+			val, ok := ctx.Value(&ctxTestKeyString{}).([]string)
 			if !ok {
-				log.Fatal("context value was not of expected type int or nil")
+				log.Fatal("context value was not of expected type []string or nil")
 			}
-			val *= 2 // 44
-			return context.WithValue(ctx, &ctxTestKeyInt{}, val), nil
+			val = append(val, "setup-1")
+			return context.WithValue(ctx, &ctxTestKeyString{}, val), nil
 		},
 		func(ctx context.Context, _ *envconf.Config) (context.Context, error) {
-			val, ok := ctx.Value(&ctxTestKeyInt{}).(int)
+			val, ok := ctx.Value(&ctxTestKeyString{}).([]string)
 			if !ok {
-				log.Fatal("context value was not of expected type int or nil")
+				log.Fatal("context value was not of expected type []string or nil")
 			}
-			val *= 2 // 88
-			return context.WithValue(ctx, &ctxTestKeyInt{}, val), nil
+			val = append(val, "setup-2")
+			return context.WithValue(ctx, &ctxTestKeyString{}, val), nil
 		},
 	).BeforeEachTest(func(ctx context.Context, _ *envconf.Config) (context.Context, error) {
 		// update before each test
-		val, ok := ctx.Value(&ctxTestKeyInt{}).(int)
+		val, ok := ctx.Value(&ctxTestKeyString{}).([]string)
 		if !ok {
-			log.Fatal("context value was not of expected type int or nil")
+			log.Fatal("context value was not of expected type []string or nil")
 		}
-		val += 2 // 90
-		return context.WithValue(ctx, &ctxTestKeyInt{}, val), nil
+		val = append(val, "before-each-test")
+		return context.WithValue(ctx, &ctxTestKeyString{}, val), nil
 	}).AfterEachTest(func(ctx context.Context, _ *envconf.Config) (context.Context, error) {
 		// update after the test
-		val, ok := ctx.Value(&ctxTestKeyInt{}).(int)
+		val, ok := ctx.Value(&ctxTestKeyString{}).([]string)
 		if !ok {
-			log.Fatal("context value was not of expected type int or nil")
+			log.Fatal("context value was not of expected type []string] or nil")
 		}
-		val--
-		return context.WithValue(ctx, &ctxTestKeyInt{}, val), nil
+		val = append(val, "after-each-test")
+		return context.WithValue(ctx, &ctxTestKeyString{}, val), nil
 	})
 
 	os.Exit(envForTesting.Run(m))


### PR DESCRIPTION
In order to check the invokation order of various hooks, the tests
were previously implemented as a sort of running tabulation. This is
incredibly hard to debug when a test fails. Instead, I modified the code
to simply append descriptive strings to a slice. This allows us to easily
track which method is being called and in which order.

Signed-off-by: John Schnake <jschnake@vmware.com>