### PR TITLE
Ensure kind and PATH are set as needed

### DIFF
--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -36,6 +36,7 @@ done
 REPO_ROOT=$(git rev-parse --show-toplevel)
 cd "${REPO_ROOT}"
 
-# not testing the examples right now
-GO111MODULE=on go test -v -timeout="${TEST_TIMEOUT}s" -count=1 -cover -coverprofile coverage.out $(go list ./...)
+# Ensure -p=1 to avoid packages running concurrently which may all try and install kind at the same time or race for
+# use of the kind binary.
+GO111MODULE=on go test -v -p=1 -timeout="${TEST_TIMEOUT}s" -count=1 -cover -coverprofile coverage.out $(go list ./...)
 go tool cover -html coverage.out -o coverage.html

--- a/klient/k8s/resources/resources_test.go
+++ b/klient/k8s/resources/resources_test.go
@@ -33,7 +33,7 @@ import (
 func TestCreate(t *testing.T) {
 	res, err := New(cfg)
 	if err != nil {
-		t.Fatalf("error creating new config: %v", err)
+		t.Fatalf("Error creating new resources object: %v", err)
 	}
 
 	// create a namespace
@@ -56,7 +56,7 @@ func TestCreate(t *testing.T) {
 func TestRes(t *testing.T) {
 	res, err := New(cfg)
 	if err != nil {
-		t.Errorf("config is nil")
+		t.Fatalf("Error creating new resources object: %v", err)
 	}
 
 	err = res.Create(context.TODO(), dep)
@@ -105,7 +105,7 @@ func TestResInvalidConfig(t *testing.T) {
 func TestUpdate(t *testing.T) {
 	res, err := New(cfg)
 	if err != nil {
-		t.Errorf("config is nil")
+		t.Fatalf("Error creating new resources object: %v", err)
 	}
 
 	depActual := getDeployment("update-test-dep-name")
@@ -140,7 +140,7 @@ func TestUpdate(t *testing.T) {
 func TestDelete(t *testing.T) {
 	res, err := New(cfg)
 	if err != nil {
-		t.Errorf("config is nil")
+		t.Fatalf("Error creating new resources object: %v", err)
 	}
 
 	depActual := getDeployment("delete-test-dep-name")
@@ -159,7 +159,7 @@ func TestDelete(t *testing.T) {
 func TestList(t *testing.T) {
 	res, err := New(cfg)
 	if err != nil {
-		t.Errorf("config is nill")
+		t.Fatalf("Error creating new resources object: %v", err)
 	}
 
 	deps := &appsv1.DeploymentList{}
@@ -188,7 +188,7 @@ func TestList(t *testing.T) {
 func TestPatch(t *testing.T) {
 	res, err := New(cfg)
 	if err != nil {
-		t.Errorf("config is nill")
+		t.Fatalf("Error creating new resources object: %v", err)
 	}
 
 	mergePatch, err := json.Marshal(map[string]interface{}{
@@ -221,7 +221,7 @@ func TestPatch(t *testing.T) {
 func TestListAllPods(t *testing.T) {
 	res, err := New(cfg)
 	if err != nil {
-		t.Errorf("config is nill")
+		t.Fatalf("Error creating new resources object: %v", err)
 	}
 
 	pods := &corev1.PodList{}

--- a/support/kind/kind.go
+++ b/support/kind/kind.go
@@ -145,6 +145,12 @@ func (k *Cluster) installKind(e *gexe.Echo) error {
 		return fmt.Errorf("failed to install kind: %s", p.Result())
 	}
 
+	// PATH may already be set to include $GOPATH/bin so we don't need to.
+	if kindPath := e.Prog().Avail("kind"); kindPath != "" {
+		log.Println("installed kind at", kindPath)
+		return nil
+	}
+
 	p = e.RunProc("ls $GOPATH/bin")
 	if p.Err() != nil {
 		return fmt.Errorf("failed to install kind: %s", p.Err())
@@ -155,7 +161,12 @@ func (k *Cluster) installKind(e *gexe.Echo) error {
 		return fmt.Errorf("failed to install kind: %s", p.Err())
 	}
 
+	log.Println(`Setting path to include $GOPATH/bin:`, p.Result())
 	e.SetEnv("PATH", p.Result())
 
-	return nil
+	if kindPath := e.Prog().Avail("kind"); kindPath != "" {
+		log.Println("installed kind at", kindPath)
+		return nil
+	}
+	return fmt.Errorf("kind not available even after installation")
 }


### PR DESCRIPTION
A problem with the presumed test invocation environment
caused multiple packages to run simultaneously. This resulted
in multiple, parallel attempts to check for, install, and use
kind.

This adds some more logging/checks that were helpful in debugging
this issue. In addition, it ensures that tests are invoked with
-p=1 to avoid packages being run concurrently.

Fixes #66 
Fixes #67 