### PR TITLE
Rework the FeatureInfo wiring

### DIFF
--- a/pkg/env/action.go
+++ b/pkg/env/action.go
@@ -71,7 +71,7 @@ func (a *action) runWithT(ctx context.Context, cfg *envconf.Config, t *testing.T
 }
 
 // runWithFeature will run the action and inject a FeatureInfo object into the callback function.
-func (a *action) runWithFeature(ctx context.Context, cfg *envconf.Config, fi types.FeatureInfo) (context.Context, error) {
+func (a *action) runWithFeature(ctx context.Context, cfg *envconf.Config, fi types.Feature) (context.Context, error) {
 	switch a.role {
 	case roleBeforeFeature, roleAfterFeature:
 		for _, f := range a.featureFuncs {

--- a/pkg/features/builder.go
+++ b/pkg/features/builder.go
@@ -38,6 +38,12 @@ func (b *FeatureBuilder) WithLabel(key, value string) *FeatureBuilder {
 	return b
 }
 
+// WithStep adds a new step that will be applied prior to feature test.
+func (b *FeatureBuilder) WithStep(name string, level Level, fn Func) *FeatureBuilder {
+	b.feat.steps = append(b.feat.steps, newStep(name, level, fn))
+	return b
+}
+
 // Setup adds a new setup step that will be applied prior to feature test.
 func (b *FeatureBuilder) Setup(fn Func) *FeatureBuilder {
 	b.feat.steps = append(b.feat.steps, newStep(fmt.Sprintf("%s-setup", b.feat.name), types.LevelSetup, fn))

--- a/pkg/internal/types/types.go
+++ b/pkg/internal/types/types.go
@@ -33,7 +33,7 @@ type EnvFunc func(context.Context, *envconf.Config) (context.Context, error)
 // can be used to customized the behavior of the
 // environment. Changes to context are expected to surface
 // to caller. Meant for use with before/after feature hooks.
-type FeatureEnvFunc func(context.Context, *envconf.Config, FeatureInfo) (context.Context, error)
+type FeatureEnvFunc func(context.Context, *envconf.Config, Feature) (context.Context, error)
 
 // TestEnvFunc represents a user-defined operation that
 // can be used to customized the behavior of the
@@ -88,12 +88,6 @@ type Feature interface {
 	Labels() Labels
 	// Steps testing tasks to test the feature
 	Steps() []Step
-}
-
-type FeatureInfo struct {
-	Name   string
-	Labels map[string]string
-	Steps  []Step
 }
 
 type Level uint8


### PR DESCRIPTION
- Removed the FeatureInfo type in favor of the Feature interface
- Added logic to make a deep copy rather than pass the feature itself
- Added a test to confirm we dont allow mutation of the feature in
the before/after hooks

Fixes #69 
Signed-off-by: John Schnake <jschnake@vmware.com>