### PR TITLE
add condition helpers and examples

### DIFF
--- a/examples/wait_for_resources/README.md
+++ b/examples/wait_for_resources/README.md
@@ -1,0 +1,86 @@
+# Waiting for Resource Changes
+
+The test harness supports several methods for querying Kubernetes object types and waiting for conditions to be met. This example shows how to create various wait conditions to drive your tests.
+
+## Waiting for a single object
+
+The wait package has built-in with utilities for waiting on Pods, Jobs, and Deployments:
+
+```go
+func TestPodRunning(t *testing.T) {
+	var err error
+	pod := v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "my-pod"}}
+	err = wait.For(conditions.New(client.Resources()).PodRunning(pod), WithImmediate())
+	if err != nil {
+		t.Error(err)
+	}
+}
+```
+
+Additionally, it is easy to wait for changes to any resource type with the `ResourceMatch` method:
+
+```go
+func TestResourceMatch(t *testing.T) {
+    ...
+    deployment := appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "deploy-name"}}
+	err = wait.For(conditions.New(client.Resources()).ResourceMatch(deployment, func(object k8s.Object) bool {
+		d := object.(*appsv1.Deployment)
+		return d.Status.AvailableReplicas == 2 && d.Status.ReadyReplicas == 2
+	}))
+	if err != nil {
+		t.Error(err)
+	}
+	...
+}
+```
+
+## Waiting for a lists of objects
+
+It is common to need to check for the existence of a set of objects by name:
+
+```go
+func TestResourcesFound(t *testing.T) {
+    ...
+	pods := &v1.PodList{
+		Items: []v1.Pod{
+			{ObjectMeta: metav1.ObjectMeta{Name: "p9", Namespace: namespace}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "p10", Namespace: namespace}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "p11", Namespace: namespace}},
+		},
+	}
+    // wait for the set of pods to exist
+	err = wait.For(conditions.New(client.Resources()).ResourcesFound(pods))
+	if err != nil {
+		t.Error(err)
+	}
+	...
+}
+```
+
+Or to check for their absence:
+
+```go
+func TestResourcesDeleted(t *testing.T) {
+    ...
+	pods := &v1.PodList{}
+    // wait for 1 pod with the label `"app": "d5"`
+	err = wait.For(conditions.New(client.Resources()).ResourceListN(
+        pods,
+        1, 
+        resources.WithLabelSelector(labels.FormatLabels(map[string]string{"app": "d5"}))),
+    )
+	if err != nil {
+		t.Error(err)
+	}
+	err = client.Resources().Delete(context.Background(), deployment)
+	if err != nil {
+		t.Error(err)
+	}
+    // wait for the set of pods to finish deleting
+	err = wait.For(conditions.New(client.Resources()).ResourcesDeleted(pods))
+	if err != nil {
+		t.Error(err)
+	}
+    ...
+}
+```

--- a/examples/wait_for_resources/main_test.go
+++ b/examples/wait_for_resources/main_test.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wait_for_resources
+
+import (
+	"os"
+	"testing"
+
+	"sigs.k8s.io/e2e-framework/pkg/env"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/envfuncs"
+)
+
+var testenv env.Environment
+
+func TestMain(m *testing.M) {
+	testenv = env.New()
+	kindClusterName := envconf.RandomName("wait-for-resources", 16)
+	namespace := envconf.RandomName("kind-ns", 16)
+	testenv.Setup(
+		envfuncs.CreateKindCluster(kindClusterName),
+		envfuncs.CreateNamespace(namespace),
+	)
+	testenv.Finish(
+		envfuncs.DeleteNamespace(namespace),
+		envfuncs.DestroyKindCluster(kindClusterName),
+	)
+	os.Exit(testenv.Run(m))
+}

--- a/examples/wait_for_resources/wait_test.go
+++ b/examples/wait_for_resources/wait_test.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wait_for_resources
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/e2e-framework/klient/k8s"
+	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
+	"sigs.k8s.io/e2e-framework/klient/wait"
+	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+)
+
+func TestWaitForResources(t *testing.T) {
+	depFeature := features.New("appsv1/deployment").WithLabel("env", "dev").
+		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			// create a deployment
+			deployment := newDeployment(cfg.Namespace(), "test-deployment", 10)
+			client, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := client.Resources().Create(ctx, deployment); err != nil {
+				t.Fatal(err)
+			}
+			return ctx
+		}).
+		Assess("deployment >=50% available", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+			dep := appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-deployment", Namespace: cfg.Namespace()},
+			}
+			// wait for the deployment to become at least 50%
+			err = wait.For(conditions.New(client.Resources()).ResourceMatch(&dep, func(object k8s.Object) bool {
+				d := object.(*appsv1.Deployment)
+				return float64(d.Status.ReadyReplicas)/float64(*d.Spec.Replicas) >= 0.50
+			}), wait.WithTimeout(time.Minute*1))
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Logf("deployment availability: %.2f%%", float64(dep.Status.ReadyReplicas)/float64(*dep.Spec.Replicas)*100)
+			return ctx
+		}).
+		Assess("deployment available", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+			dep := appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-deployment", Namespace: cfg.Namespace()},
+			}
+			// wait for the deployment to finish becoming available
+			err = wait.For(conditions.New(client.Resources()).DeploymentConditionMatch(&dep, appsv1.DeploymentAvailable, v1.ConditionTrue), wait.WithTimeout(time.Minute*1))
+			if err != nil {
+				t.Fatal(err)
+			}
+			return ctx
+		}).
+		Assess("deployment pod garbage collection", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+			// get list of pods
+			var pods v1.PodList
+			err = client.Resources(cfg.Namespace()).List(context.TODO(), &pods, resources.WithLabelSelector(labels.FormatLabels(map[string]string{"app": "wait-for-resources"})))
+			if err != nil {
+				t.Fatal(err)
+			}
+			// delete the deployment
+			dep := appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-deployment", Namespace: cfg.Namespace()},
+			}
+			err = client.Resources(cfg.Namespace()).Delete(context.TODO(), &dep)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// wait for the deployment pods to be deleted
+			err = wait.For(conditions.New(client.Resources()).ResourcesDeleted(&pods), wait.WithTimeout(time.Minute*1))
+			if err != nil {
+				t.Fatal(err)
+			}
+			return ctx
+		}).Feature()
+
+	testenv.Test(t, depFeature)
+}
+
+func newDeployment(namespace string, name string, replicas int32) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, Labels: map[string]string{"app": "wait-for-resources"}},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "wait-for-resources"},
+			},
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "wait-for-resources"}},
+				Spec:       v1.PodSpec{Containers: []v1.Container{{Name: "nginx", Image: "nginx"}}},
+			},
+		},
+	}
+}

--- a/klient/wait/wait_test.go
+++ b/klient/wait/wait_test.go
@@ -25,8 +25,11 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 
 	"sigs.k8s.io/e2e-framework/klient/k8s"
+	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
 	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
 )
 
@@ -112,6 +115,124 @@ func TestResourceScaled(t *testing.T) {
 	}, 2), WithStopChannel(stopChan))
 	if err != nil {
 		t.Error("failed waiting for resource to be scaled", err)
+	}
+	log.Info("Done")
+}
+
+func TestDeploymentConditionMatch(t *testing.T) {
+	var err error
+	deployment := createDeployment("d2", 3, t)
+	err = For(conditions.New(getResourceManager()).DeploymentConditionMatch(deployment, appsv1.DeploymentAvailable, v1.ConditionTrue))
+	if err != nil {
+		t.Error("failed waiting for deployment to become available", err)
+	}
+	log.Info("Done")
+}
+
+func TestResourceListN(t *testing.T) {
+	var err error
+	createDeployment("d3", 4, t)
+	pods := &v1.PodList{}
+	err = For(conditions.New(getResourceManager()).ResourceListN(pods, 4, resources.WithLabelSelector(labels.FormatLabels(map[string]string{"app": "d3"}))))
+	if err != nil {
+		t.Error("failed waiting for deployment pods to be created", err)
+	}
+	log.Info("Done")
+}
+
+func TestResourceListMatchN(t *testing.T) {
+	var err error
+	createDeployment("d4", 5, t)
+	pods := &v1.PodList{}
+	err = For(conditions.New(getResourceManager()).ResourceListMatchN(pods, 5, func(object k8s.Object) bool {
+		for _, c := range object.(*v1.Pod).Spec.Containers {
+			if c.Image == "nginx" {
+				return true
+			}
+		}
+		return false
+	}, resources.WithLabelSelector(labels.FormatLabels(map[string]string{"app": "d4"}))))
+	if err != nil {
+		t.Error("failed waiting for deployment pods with nginx containers to be created", err)
+	}
+	log.Info("Done")
+}
+
+func TestResourcesMatch(t *testing.T) {
+	var err error
+	go func() {
+		createPod("p6", t)
+		createPod("p7", t)
+		createPod("p8", t)
+	}()
+	pods := &v1.PodList{
+		Items: []v1.Pod{
+			{ObjectMeta: metav1.ObjectMeta{Name: "p6", Namespace: namespace}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "p7", Namespace: namespace}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "p8", Namespace: namespace}},
+		},
+	}
+	err = For(conditions.New(getResourceManager()).ResourcesMatch(pods, func(object k8s.Object) bool {
+		return object.(*v1.Pod).Status.Phase == v1.PodRunning
+	}))
+	if err != nil {
+		t.Error("failed waiting for deployment pods to start running", err)
+	}
+	log.Info("Done")
+}
+
+func TestResourcesFound(t *testing.T) {
+	var err error
+	go func() {
+		createPod("p9", t)
+		createPod("p10", t)
+		createPod("p11", t)
+	}()
+	pods := &v1.PodList{
+		Items: []v1.Pod{
+			{ObjectMeta: metav1.ObjectMeta{Name: "p9", Namespace: namespace}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "p10", Namespace: namespace}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "p11", Namespace: namespace}},
+		},
+	}
+	err = For(conditions.New(getResourceManager()).ResourcesFound(pods))
+	if err != nil {
+		t.Error("failed waiting for deployment pods to be created", err)
+	}
+	log.Info("Done")
+}
+
+func TestResourcesDeleted(t *testing.T) {
+	var err error
+	deployment := createDeployment("d5", 1, t)
+	pods := &v1.PodList{}
+	err = For(conditions.New(getResourceManager()).ResourceListN(pods, 1, resources.WithLabelSelector(labels.FormatLabels(map[string]string{"app": "d5"}))))
+	if err != nil {
+		t.Error("failed waiting for deployment pods to be created", err)
+	}
+	err = getResourceManager().Delete(context.Background(), deployment)
+	if err != nil {
+		t.Error("failed to delete deployment due to an error", err)
+	}
+	err = For(conditions.New(getResourceManager()).ResourcesDeleted(pods))
+	if err != nil {
+		t.Error("failed waiting for pods to be deleted", err)
+	}
+	log.Info("Done")
+}
+
+func TestResourceMatch(t *testing.T) {
+	var err error
+	deployment := createDeployment("d6", 2, t)
+	err = For(conditions.New(getResourceManager()).ResourceMatch(deployment, func(object k8s.Object) bool {
+		d, ok := object.(*appsv1.Deployment)
+		if !ok {
+			t.Fatalf("unexpected type %T in list, does not satisfy *appsv1.Deployment", object)
+		}
+		return d.Status.AvailableReplicas == 2 && d.Status.ReadyReplicas == 2
+	}))
+	if err != nil {
+		t.Error("failed waiting for deployment replicas", err)
 	}
 	log.Info("Done")
 }


### PR DESCRIPTION
While reviewing the conditions package I noticed there weren't any functions to help deal with lists of objects nor helpers built around `k8s.Object` to deal with types outside of pod, jobs, and other core types.

I think I should be able to use any type in my codebase now.

Saw #78 --  so I tried to add some examples as well.