### PR TITLE
use stdout from kind command when writing kubeconfig

### DIFF
--- a/support/kind/kind.go
+++ b/support/kind/kind.go
@@ -17,6 +17,7 @@ limitations under the License.
 package kind
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -48,8 +49,16 @@ func (k *Cluster) WithVersion(ver string) *Cluster {
 
 func (k *Cluster) getKubeconfig() (string, error) {
 	kubecfg := fmt.Sprintf("%s-kubecfg", k.name)
-	p := k.e.RunProc(fmt.Sprintf(`kind get kubeconfig --name %s`, k.name))
+
+	p := k.e.StartProc(fmt.Sprintf(`kind get kubeconfig --name %s`, k.name))
 	if p.Err() != nil {
+		return "", fmt.Errorf("kind get kubeconfig: %w", p.Err())
+	}
+	var stdout bytes.Buffer
+	if _, err := stdout.ReadFrom(p.StdOut()); err != nil {
+		return "", fmt.Errorf("kind kubeconfig stdout bytes: %w", err)
+	}
+	if p.Wait().Err() != nil {
 		return "", fmt.Errorf("kind get kubeconfig: %s: %w", p.Result(), p.Err())
 	}
 
@@ -61,7 +70,7 @@ func (k *Cluster) getKubeconfig() (string, error) {
 
 	k.kubecfgFile = file.Name()
 
-	if n, err := io.Copy(file, strings.NewReader(p.Result())); n == 0 || err != nil {
+	if n, err := io.Copy(file, &stdout); n == 0 || err != nil {
 		return "", fmt.Errorf("kind kubecfg file: bytes copied: %d: %w]", n, err)
 	}
 


### PR DESCRIPTION
When running kind with podman, an extra log appears that is getting picked up by the `support/kind` package and breaking:

Example:
```bash
# kind version
kind v0.11.1 go1.16.4 linux/amd64
# kind get clusters
enabling experimental podman provider
myclustername1
```

https://github.com/kubernetes-sigs/kind/blob/fa7d86470f4c0e924fc4c2e767ec8491c45f4304/pkg/cluster/internal/providers/podman/provider.go#L45

This is output when running `kind get kubeconfig` to stderr -- the current processes combine stdout + stderr and results in an invalid yaml file.

This change writes only the stdout contents to the kubeconfig file. An alternative might be to run `kind get kubeconfig` with the `-q` flag.