### PR TITLE
support loading images into kind cluster

### DIFF
--- a/pkg/envfuncs/kind_funcs.go
+++ b/pkg/envfuncs/kind_funcs.go
@@ -102,3 +102,51 @@ func DestroyKindCluster(name string) env.Func {
 		return ctx, nil
 	}
 }
+
+// LoadDockerImageToCluster returns an EnvFunc that
+// retrieves a previously saved kind Cluster in the context (using the name), and then loads a docker image
+// from the host into the cluster.
+//
+func LoadDockerImageToCluster(name, image string) env.Func {
+	return func(ctx context.Context, cfg *envconf.Config) (context.Context, error) {
+		clusterVal := ctx.Value(kindContextKey(name))
+		if clusterVal == nil {
+			return ctx, fmt.Errorf("load docker image func: context cluster is nil")
+		}
+
+		cluster, ok := clusterVal.(*kind.Cluster)
+		if !ok {
+			return ctx, fmt.Errorf("load docker image func: unexpected type for cluster value")
+		}
+
+		if err := cluster.LoadDockerImage(image); err != nil {
+			return ctx, fmt.Errorf("load docker image: %w", err)
+		}
+
+		return ctx, nil
+	}
+}
+
+// LoadImageArchiveToCluster returns an EnvFunc that
+// retrieves a previously saved kind Cluster in the context (using the name), and then loads a docker image TAR archive
+// from the host into the cluster.
+//
+func LoadImageArchiveToCluster(name, imageArchive string) env.Func {
+	return func(ctx context.Context, cfg *envconf.Config) (context.Context, error) {
+		clusterVal := ctx.Value(kindContextKey(name))
+		if clusterVal == nil {
+			return ctx, fmt.Errorf("load image archive func: context cluster is nil")
+		}
+
+		cluster, ok := clusterVal.(*kind.Cluster)
+		if !ok {
+			return ctx, fmt.Errorf("load image archive func: unexpected type for cluster value")
+		}
+
+		if err := cluster.LoadImageArchive(imageArchive); err != nil {
+			return ctx, fmt.Errorf("load image archive: %w", err)
+		}
+
+		return ctx, nil
+	}
+}

--- a/support/kind/kind.go
+++ b/support/kind/kind.go
@@ -201,3 +201,21 @@ func (k *Cluster) installKind(e *gexe.Echo) error {
 	}
 	return fmt.Errorf("kind not available even after installation")
 }
+
+// LoadDockerImage loads a docker image from the host into the kind cluster
+func (k *Cluster) LoadDockerImage(image string) error {
+	p := k.e.RunProc(fmt.Sprintf(`kind load docker-image --name %s %s`, k.name, image))
+	if p.Err() != nil {
+		return fmt.Errorf("kind: load docker-image failed: %s: %s", p.Err(), p.Result())
+	}
+	return nil
+}
+
+// LoadImageArchive loads a docker image TAR archive from the host into the kind cluster
+func (k *Cluster) LoadImageArchive(imageArchive string) error {
+	p := k.e.RunProc(fmt.Sprintf(`kind load image-archive --name %s %s`, k.name, imageArchive))
+	if p.Err() != nil {
+		return fmt.Errorf("kind: load image-archive failed: %s: %s", p.Err(), p.Result())
+	}
+	return nil
+}


### PR DESCRIPTION
Support loading docker images from the host to the kind cluster:
-  `kind load docker-image --name ${cluster} ${dockerImage}`
-  `kind load image-archive --name ${cluster} ${dockerImage}`

https://kind.sigs.k8s.io/docs/user/quick-start/#loading-an-image-into-your-cluster