### PR TITLE
add yaml and json helpers

### DIFF
--- a/docs/design/resource-decoding.md
+++ b/docs/design/resource-decoding.md
@@ -1,0 +1,323 @@
+# Decoding Resources
+
+This document proposes the design for a set of decoding functions a new package, `klient/decoder`, intended to provide utilities for creating `k8s.Object` types from common sources of input in Go programs: files, strings, or any type that satisfies the [io.Reader](https://pkg.go.dev/io#Reader) interface.  The goal of these decoding functions is to provide an easy way for test developers to interact with Kubernetes objects in their Go tests.
+
+## Table of Contents
+
+1. [Motivation](#Motivation)
+2. [Supported object formats](#Supported-object-formats)
+3. [Goals](#Goals)
+4. [Non-Goals](#Non-Goals)
+5. [Design Components](#Design-Components)
+    * [Decoding Options](#Decoding-Options)
+    * [Handlers](#Handlers)
+    * [Decoding a single-document YAML/JSON input](#decoding-a-single-document-yamljson-input)
+    * [Decoding a multi-document YAML/JSON input](#decoding-a-multi-document-yamljson-input)
+        * [Decoding to a known object type](#decoding-without-knowing-the-object-type)
+        * [Decoding without knowing the object type](#decoding-without-knowing-the-object-type)
+6. [Decode Proposal](#Decode-Proposal)
+    * [Pre-defined Decoders](#Pre-defined-Decoders)
+    * [Pre-defined Helpers](#Pre-defined-Helpers)
+
+## Motivation
+
+When developing tests that are meant to utilize Kubernetes APIs, it is expected that you will construct a `k8s.Object` type in order to use many functions defined in the `e2e-framework` packages (as in the `klient` package).
+
+This may be accomplished by defining Go structs, importing stdlib or third-party code.
+
+When developing many tests, the verbosity and complexity of defining many types and understanding which packages to import may add a burden to test developers. Managing these resources as YAML or JSON has obvious benefits in regard to maintainability (and even extensibility), as they are how these resource types are traditionally represented in documentation and utilized in actual deployments.
+
+In Go, `testdata` is a special directory that can be used to store such test fixtures, and using such a testdata directory as a source of easy-to-manage files is a common pattern associated with table-driven testing.
+
+Finally, to help develop feature tests, it is common to need to have a set of resources created before a feature assessment begins. Similarly, deleting a set of resources may be required in a teardown step.
+
+## Supported object formats
+
+- YAML
+- JSON
+
+## Goals
+
+- Support decoding [single-document](https://yaml.org/spec/1.2.2/#91-documents) YAML/JSON input
+- Support decoding a [multi-document](https://yaml.org/spec/1.2.2/#92-streams) YAML/JSON stream input
+- Accept io.Reader interface as input
+
+## Non-Goals
+
+- Encoding Objects
+
+## Design Components
+
+### **Decoding Options**
+
+```go
+type DecodeOption struct {
+	DefaultGVK  *schema.GroupVersionKind
+	MutateFuncs []MutateFunc
+}
+
+type DecodeOption func(*DecodeOption)
+
+type MutateFunc func(k8s.Object) error
+```
+
+All decoding functions accept a `options ...DecodeOption` argument. Options may be used to apply "patches", or post-decoding mutations to Objects to inject data
+after decoding is completed. Additionally, the Group Version Kind may be specified to instruct the decoding process on the type to use.
+
+If a MutateFunc returns an error, decoding is halted.
+
+This may be done to inject dynamic data that may not be known until runtime or that may be sensitive like a locally valid credential.
+
+Example pre-defined MutateFuncs, wrapped as DecodeOptions:
+
+```go
+// apply an override set of labels to a decoded object
+func MutateLabels(overrides map[string]string) DecodeOption
+// apply an override set of annotations to a decoded object
+func MutateAnnotations(overrides map[string]string) DecodeOption
+// apply an owner annotation to a decoded object
+func MutateOwnerAnnotations(owner k8s.Object) DecodeOption
+```
+
+### **Handlers**
+
+Some decoding functions accept a HandlerFunc, a function that is executed after decoding and the optional patches are completed per each object.
+
+If a HandlerFunc returns an error, decoding is halted.
+
+```go
+type HandlerFunc func(context.Context, k8s.Object) error
+```
+
+Example pre-defined HandlerFuncs:
+
+```go
+// CreateHandler returns a HandlerFunc that will create objects
+func CreateHandler(*resources.Resources, opts ...CreateOption) HandlerFunc
+// UpdateHandler returns a HandlerFunc that will update objects
+func UpdateHandler(*resources.Resources, opts ...UpdateOption) HandlerFunc
+// DeleteHandler returns a HandlerFunc that will delete objects
+func DeleteHandler(*resources.Resources, opts ...DeleteOption) HandlerFunc
+
+// IgnoreErrorHandler returns a HandlerFunc that will ignore an error
+func IgnoreErrorHandler(HandlerFunc, error) HandlerFunc
+
+// CreateIfNotExistsHandler returns a HandlerFunc that will create objects if they do not already exist
+func CreateIfNotExistsHandler(*resources.Resources, opts ...CreateOption) HandlerFunc
+```
+
+### Decoding a single-document YAML/JSON input
+
+The following are proposed function signatures for decoding input that contain a single `k8s.Object` type. Example:
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: my-serivce-account
+  namespace: myappns
+```
+
+1. Decoding an object to a known type
+
+```go
+func Decode(manifest io.Reader, obj k8s.Object, options ...DecodeOption) error
+```
+
+Usage:
+
+```go
+sa := v1.ServiceAccount{}
+err := Decode(strings.NewReader("..."), &sa)
+```
+
+With a MutateFunc:
+
+```go
+// Decode to sa and apply the label "test" : "feature-X"
+sa := v1.ServiceAccount{}
+err := Decode(strings.NewReader("..."), &sa, MutateLabels(map[string]string{"test" : "feature-X"}))
+```
+
+2. Decoding an object without knowing the type
+
+`defaults` is an optional parameter, if specified, it is a hint to the decoder to help determine the underlying Go type to use for object creation.
+
+```go
+func DecodeAny(manifest io.Reader, options ...DecodeOption) (k8s.Object, error)
+```
+
+Usage:
+
+```go
+obj, err := DecodeAny(strings.NewReader("..."))
+if err != nil {
+    ...
+}
+if sa, ok := obj.(*v1.ServiceAccount); ok {
+    ...
+}
+```
+
+With defaults:
+
+```go
+obj, err := DecodeAny(strings.NewReader("..."), schema.GroupVersionKind{Version: "v1", Kind: "ServiceAccount"})
+if err != nil {
+    ...
+}
+if sa, ok := obj.(*v1.ServiceAccount); ok {
+    ...
+}
+```
+
+### Decoding a multi-document YAML/JSON input
+
+The following are proposed function signatures for decoding input that may contain multiple distinct `k8s.Object` types. Example:
+
+```yaml
+## testdata/test-setup.yaml
+apiVersion: v1
+kind: Namespace
+name: myappns
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-config
+  namespace: myappns
+data:
+  appconfig.json: |
+    key: value
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: my-serivce-account
+  namespace: myappns
+```
+
+#### **Decoding without knowing the object type**
+
+The following options would use the types registered with `scheme.Scheme` to help deserialize objects into a `k8s.Object` with the expected underlying API type.
+
+`defaults` is an optional parameter, if specified, it is a hint to the decoder to help determine the underlying Go type to use for object creation.
+
+1. Decode each document and call handlerFn for each processed object. If `handlerFn` returns an error, decoding is halted.
+
+```go
+func DecodeEach(ctx context.Context, manifest io.Reader, handlerFn HandlerFunc, options ...DecodeOption) error
+```
+
+Usage:
+
+
+```go
+list := &unstructured.UnstructuredList{}
+err := DecodeEach(context.TODO(), strings.NewReader("..."), func(ctx context.Context, obj ks8.Object) error {
+    if cfg, ok := obj.(*v1.ConfigMap); ok {
+        // obj is a ConfigMap
+    } else if svc, ok := obj.(*v1.ServiceAccount); ok {
+        // obj is a ServiceAccount
+    }
+    return klient.Create(obj)
+})
+```
+
+Usage with pre-defined HandlerFunc:
+
+```go
+err := DecodeEach(context.TODO(), strings.NewReader("..."), CreateHandler(klient.Resources(namespace)))
+```
+
+
+2. Decode all documents.
+
+```go
+func DecodeAll(ctx context.Context, manifest io.Reader, options ...DecodeOption) ([]k8s.Object, error)
+```
+
+Usage:
+
+```go
+objects, err := DecodeAll(context.TODO(), strings.NewReader("..."))
+for _, obj := range objects {
+    err := klient.Create(obj)
+    ...
+}
+```
+
+## Decode Proposal
+
+The following is a final proposal on the function signatures, after considering the above options:
+
+```go
+// Decode a single-document YAML or JSON input into a known type.
+// Patches are optional and applied after decoding.
+func Decode(manifest io.Reader, obj k8s.Object, options ...DecodeOption) error
+
+// Decode any single-document YAML or JSON input using either the innate typing of the scheme or the default kind, group, and version provided.
+// Patches are optional and applied after decoding.
+func DecodeAny(manifest io.Reader, options ...DecodeOption) (k8s.Object, error)
+
+// Decode a stream of documents of any Kind using either the innate typing of the scheme or the default kind, group, and version provided. 
+// If handlerFn returns an error, decoding is halted.
+// Patches are optional and applied after decoding and before handlerFn is executed.
+func DecodeEach(ctx context.Context, manifest io.Reader, handlerFn HandlerFunc, options ...DecodeOption) error
+
+// Decode a stream of  documents of any Kind using either the innate typing of the scheme.
+// Falls back to the unstructured.Unstructured type if a matching type cannot be found for the Kind.
+// Options may be provided to configure the behavior of the decoder.
+func DecodeAll(ctx context.Context, manifest io.Reader, options ...DecodeOption) ([]k8s.Object, error)
+```
+
+Using a typed object when decoding multiple documents does not provide for an easy-to-use interface, so they are not being proposed at this time.
+
+### Pre-defined Decoders
+
+Building on the proposal, the following functions would be included that build on the base decoders:
+
+```go
+// Decode the file at the given manifest path into the provided object. Patches are optional and applied after decoding.
+func DecodeFile(fsys fs.FS, manifestPath string, obj k8s.Object, options ...DecodeOption) error
+
+// Decode the manifest string into the provided object. Patches are optional and applied after decoding.
+func DecodeString(rawManifest string, obj k8s.Object, options ...DecodeOption) error
+
+// Decode the manifest bytes into the provided object. Patches are optional and applied after decoding.
+func DecodeBytes(manifestBytes []byte, obj k8s.Object, options ...DecodeOption) error
+
+// DecodeEachFile resolves files at the filesystem matching the pattern, decoding JSON or YAML files. Supports multi-document files.
+//
+// If handlerFn returns an error, decoding is halted.
+// Options may be provided to configure the behavior of the decoder.
+func DecodeEachFile(ctx context.Context, fsys fs.FS, pattern string, handlerFn HandlerFunc, options ...DecodeOption) error
+
+// DecodeAllFiles  resolves files at the filesystem matching the pattern, decoding JSON or YAML files. Supports multi-document files.
+// Falls back to the unstructured.Unstructured type if a matching type cannot be found for the Kind.
+// Options may be provided to configure the behavior of the decoder.
+func DecodeAllFiles(ctx context.Context, fsys fs.FS, pattern string, options ...DecodeOption) ([]k8s.Object, error)
+```
+### Pre-defined Helpers
+
+```go
+// CreateHandler returns a HandlerFunc that will create objects
+func CreateHandler(r *resources.Resources, opts ...CreateOption) HandlerFunc
+// UpdateHandler returns a HandlerFunc that will update objects
+func UpdateHandler(r *resources.Resources, opts ...UpdateOption) HandlerFunc
+// DeleteHandler returns a HandlerFunc that will delete objects
+func DeleteHandler(r *resources.Resources, opts ...DeleteOption) HandlerFunc
+
+// IgnoreErrorHandler returns a HandlerFunc that will ignore the provided error
+func IgnoreErrorHandler(HandlerFunc, error) HandlerFunc
+
+// CreateIfNotExistsHandler returns a HandlerFunc that will create objects if they do not already exist
+func CreateIfNotExistsHandler(r *resources.Resources, opts ...CreateOption) HandlerFunc
+
+// apply an override set of labels to a decoded object
+func MutateLabels(overrides map[string]string) DecodeOption
+// apply an override set of annotations to a decoded object
+func MutateAnnotations(overrides map[string]string) DecodeOption
+// apply an owner annotation to a decoded object
+func MutateOwnerAnnotations(owner k8s.Object) DecodeOption
+```

--- a/examples/decoder/README.md
+++ b/examples/decoder/README.md
@@ -1,0 +1,176 @@
+# Decoding Kubernetes Objects
+
+This package demonstrates how to use the `klient/decoder` package in coordination with the test framework to use YAML or JSON representations of `k8s.Object` from any `io.Reader` or `fs.FS` compatible source to create resources to use in tests.
+
+The decoder package supports decoding YAML or JSON encoded Kubernetes objects from files, strings, and byte slices (any `io.Readder`).
+
+`MutateFunc` and `HandlerFunc` variations allow for various workflows:
+- Load a set of YAML or JSON files to create objects in a feature Setup
+- Delete a set of Kubernetes objects in a feature Teardown
+- Load and patch a set of resources, injecting a dynamic namespace field
+- Apply resource changes based on easily edited files
+- Create/Delete resources in a `testenv.Setup` or `testenv.Teardown` function
+
+## Decoding in a Setup Function
+
+Kubernetes objects may be represented as a string for convenience:
+
+```go
+var initYAML string = `
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mytest-namespace
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mysa
+  namespace: mytest-namespace
+`
+```
+
+Multi-document decoding support allows multiple Kubernetes objects to be decoded from one io.Reader, as represented above.
+
+To create a set of objects from a YAML document stream, before tests are run, call the decoder
+in a testenv.Setup `env.Func`, passing it a `decoder.CreateHandler` to handle creation:
+```go
+    testenv.Setup(
+		envfuncs.CreateKindCluster(kindClusterName),
+		func(ctx context.Context, cfg *envconf.Config) (context.Context, error) {
+			r, err := resources.New(cfg.Client().RESTConfig())
+			if err != nil {
+				return ctx, err
+			}
+			// decode and create a stream of YAML or JSON documents from an io.Reader
+			decoder.DecodeEach(ctx, strings.NewReader(initYAML), decoder.CreateHandler(r))
+			return ctx, nil
+		},
+	)
+```
+
+## Decoding Objects
+
+To decode an object from an `io.Reader`, the `decoder` package offers many options.
+
+The simplest options include:
+
+Decoding from a single file:
+
+```go
+    ...
+    .Assess("Single File", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+		f, err := os.Open("testdata/configmap.yaml")
+		if err != nil {
+			t.Fatal(err)
+		}
+		obj, err := decoder.DecodeAny(f)
+		if err != nil {
+			t.Fatal(err)
+		}
+		configMap, ok := obj.(*v1.ConfigMap)
+		if !ok {
+			t.Fatal("object decoded to unexpected type")
+		}
+		t.Log(configMap)
+		return ctx
+	})
+    ...
+```
+
+Or, decoding a set of files:
+
+```go
+    testdata := os.DirFS("testdata")
+	pattern := "*"
+    ...
+    .Assess("Multiple Files", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+		objects, err := decoder.DecodeAllFiles(ctx, testdata, pattern)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, obj := range objects {
+			t.Log(obj.GetObjectKind(), obj.GetNamespace(), obj.GetName())
+		}
+		return ctx
+	})
+    ...
+```
+
+## Decoding with HandlerFuncs
+
+Some decoder functions accept a `HandlerFunc`, which specify a function to execute with the decoded object after decoding and any defined MutateFunc options are applied.
+
+The decoder package includes a number of built-in HandlerFuncs that allow for basic CRUD (Create, Update, Read, and Delete) operations:
+
+```go
+// CreateHandler returns a HandlerFunc that will create objects
+func CreateHandler(r *resources.Resources, opts ...resources.CreateOption) HandlerFunc
+
+// ReadHandler returns a HandlerFunc that will use the provided object's Kind / Namespace / Name to retrieve
+// the current state of the object using the provided Resource client.
+// This helper makes it easy to use a stale reference to an object to retrieve its current version.
+func ReadHandler(r *resources.Resources, handler HandlerFunc) HandlerFunc
+
+// UpdateHandler returns a HandlerFunc that will update objects
+func UpdateHandler(r *resources.Resources, opts ...resources.UpdateOption) HandlerFunc
+
+// DeleteHandler returns a HandlerFunc that will delete objects
+func DeleteHandler(r *resources.Resources, opts ...resources.DeleteOption) HandlerFunc
+```
+
+A common pattern in tests is to create a set of resources in a `Setup` function, and consequently delete them in a Teardown:
+
+```go
+// use files matching the Glob testdata/* in the following tests
+testdata := os.DirFS("testdata")
+pattern := "*"
+features.New("setup and teardown").
+    Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+        r, err := resources.New(cfg.Client().RESTConfig())
+        if err != nil {
+            t.Fatal(err)
+        }
+
+        if err := decoder.DecodeEachFile(ctx, testdata, pattern,
+            decoder.CreateHandler(r),           // try to CREATE objects after decoding
+            decoder.MutateNamespace(namespace), // inject a namespace into decoded objects, before calling CreateHandler
+        ); err != nil {
+            t.Fatal(err)
+        }
+        return ctx
+    }).
+    ... // An assessment function would be able to use or test the created resources
+    Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+        // remove test resources before exiting
+        r, err := resources.New(cfg.Client().RESTConfig())
+        if err != nil {
+            t.Fatal(err)
+        }
+        if err := decoder.DecodeEachFile(ctx, testdata, pattern,
+            decoder.DeleteHandler(r),           // try to DELETE objects after decoding
+            decoder.MutateNamespace(namespace), // inject a namespace into decoded objects, before calling DeleteHandler
+        ); err != nil {
+            t.Fatal(err)
+        }
+        return ctx
+    }).Feature()
+```
+
+The `decoder.MutateNamespace(namespace)`  DecodeOption injects the dynamically generated namespace into the decoded objects before it tries to create or delete them from the test cluster.
+
+The decoder package includes a number of built-in MutateFunc DecodeOptions to perform common operations:
+
+```go
+// MutateLabels is an optional parameter to decoding functions that will patch an objects metadata.labels
+func MutateLabels(overrides map[string]string) DecodeOption
+
+// MutateAnnotations is an optional parameter to decoding functions that will patch an objects metadata.annotations
+func MutateAnnotations(overrides map[string]string) DecodeOption
+
+// MutateOwnerAnnotations is an optional parameter to decoding functions that will patch objects using the given owner object
+func MutateOwnerAnnotations(owner k8s.Object) DecodeOption
+
+// MutateNamespace is an optional parameter to decoding functions that will patch objects with the given namespace name
+func MutateNamespace(namespace string) DecodeOption
+```

--- a/examples/decoder/decoder_test.go
+++ b/examples/decoder/decoder_test.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package decoder
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/e2e-framework/klient/decoder"
+	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+)
+
+func TestDecoder(t *testing.T) {
+	// use files matching the Glob testdata/* in the following tests
+	testdata := os.DirFS("testdata")
+	pattern := "*"
+
+	decodeAll := features.New("decoding objects").Assess("Single File", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+		f, err := os.Open("testdata/configmap.yaml")
+		if err != nil {
+			t.Fatal(err)
+		}
+		obj, err := decoder.DecodeAny(f)
+		if err != nil {
+			t.Fatal(err)
+		}
+		configMap, ok := obj.(*v1.ConfigMap)
+		if !ok {
+			t.Fatal("object decoded to unexpected type")
+		}
+		t.Log(configMap)
+		return ctx
+	}).Assess("Multiple Files", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+		objects, err := decoder.DecodeAllFiles(ctx, testdata, pattern)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, obj := range objects {
+			t.Log(obj.GetObjectKind(), obj.GetNamespace(), obj.GetName())
+		}
+		return ctx
+	}).Feature()
+
+	decoderHandlerFuncs := features.New("setup and teardown").
+		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			r, err := resources.New(cfg.Client().RESTConfig())
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if err := decoder.DecodeEachFile(ctx, testdata, pattern,
+				decoder.CreateHandler(r),           // try to CREATE objects after decoding
+				decoder.MutateNamespace(namespace), // inject a namespace into decoded objects, before calling CreateHandler
+			); err != nil {
+				t.Fatal(err)
+			}
+			return ctx
+		}).
+		Assess("objects created", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+			// check for decoded object object creation
+			if err := client.Resources(namespace).Get(ctx, "my-config", namespace, &v1.ConfigMap{}); err != nil {
+				t.Fatal(err)
+			}
+			if err := client.Resources(namespace).Get(ctx, "myapp", namespace, &appsv1.Deployment{}); err != nil {
+				t.Fatal(err)
+			}
+			if err := client.Resources(namespace).Get(ctx, "myapp", namespace, &v1.Service{}); err != nil {
+				t.Fatal(err)
+			}
+
+			return ctx
+		}).
+		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			// remove test resources before exiting
+			r, err := resources.New(cfg.Client().RESTConfig())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := decoder.DecodeEachFile(ctx, testdata, pattern,
+				decoder.DeleteHandler(r),           // try to DELETE objects after decoding
+				decoder.MutateNamespace(namespace), // inject a namespace into decoded objects, before calling DeleteHandler
+			); err != nil {
+				t.Fatal(err)
+			}
+			return ctx
+		}).Feature()
+
+	testenv.Test(t, decodeAll, decoderHandlerFuncs)
+}

--- a/examples/decoder/main_test.go
+++ b/examples/decoder/main_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package decoder
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"sigs.k8s.io/e2e-framework/klient/decoder"
+	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
+	"sigs.k8s.io/e2e-framework/pkg/env"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/envfuncs"
+)
+
+var (
+	testenv env.Environment
+
+	namespace string = envconf.RandomName("decoder-ns", 16)
+)
+
+var initYAML string = `
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: %s
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mysa
+  namespace: %s
+`
+
+func TestMain(m *testing.M) {
+	testenv = env.New()
+	kindClusterName := envconf.RandomName("decoder", 16)
+	initYAML = fmt.Sprintf(initYAML, namespace, namespace)
+
+	testenv.Setup(
+		envfuncs.CreateKindCluster(kindClusterName),
+		func(ctx context.Context, cfg *envconf.Config) (context.Context, error) {
+			r, err := resources.New(cfg.Client().RESTConfig())
+			if err != nil {
+				return ctx, err
+			}
+			// decode and create a stream of YAML or JSON documents from an io.Reader
+			decoder.DecodeEach(ctx, strings.NewReader(initYAML), decoder.CreateHandler(r))
+			return ctx, nil
+		},
+	)
+	testenv.Finish(
+		envfuncs.DeleteNamespace(namespace),
+		envfuncs.DestroyKindCluster(kindClusterName),
+	)
+	os.Exit(testenv.Run(m))
+}

--- a/examples/decoder/testdata/configmap.yaml
+++ b/examples/decoder/testdata/configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-config
+data:
+  example.yaml: |
+    key: value

--- a/examples/decoder/testdata/deployment.yaml
+++ b/examples/decoder/testdata/deployment.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myapp
+spec:
+  selector:
+    matchLabels:
+      app: myapp
+  template:
+    metadata:
+      labels:
+        app: myapp
+    spec:
+      serviceAccount: mysa
+      containers:
+      - name: nginx
+        image: nginx
+        resources:
+          limits:
+            memory: "128Mi"
+            cpu: "500m"
+        ports:
+        - containerPort: 80

--- a/examples/decoder/testdata/service.json
+++ b/examples/decoder/testdata/service.json
@@ -1,0 +1,18 @@
+{
+    "apiVersion": "v1",
+    "kind": "Service",
+    "metadata": {
+      "name": "myapp"
+    },
+    "spec": {
+      "selector": {
+        "app": "myapp"
+      },
+      "ports": [
+        {
+          "port": 80,
+          "targetPort": 80
+        }
+      ]
+    }
+}

--- a/klient/decoder/decoder.go
+++ b/klient/decoder/decoder.go
@@ -1,0 +1,334 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package decoder
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"strings"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/e2e-framework/klient/k8s"
+	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
+)
+
+// Options are a set of configurations used to instruct the decoding process and otherwise
+// alter the output of decoding operations.
+type Options struct {
+	DefaultGVK  *schema.GroupVersionKind
+	MutateFuncs []MutateFunc
+}
+
+// DecodeOption is a function that alters the configuration Options used to decode and optionally mutate objects via MutateFuncs
+type DecodeOption func(*Options)
+
+// MutateFunc is a function executed after an object is decoded to alter its state in a pre-defined way, and can be used to apply defaults.
+// Returning an error halts decoding of any further objects.
+type MutateFunc func(obj k8s.Object) error
+
+// HandlerFunc is a function executed after an object has been decoded and patched. If an error is returned, further decoding is halted.
+type HandlerFunc func(ctx context.Context, obj k8s.Object) error
+
+// DecodeEachFile resolves files at the filesystem matching the pattern, decoding JSON or YAML files. Supports multi-document files.
+//
+// If handlerFn returns an error, decoding is halted.
+// Options may be provided to configure the behavior of the decoder.
+func DecodeEachFile(ctx context.Context, fsys fs.FS, pattern string, handlerFn HandlerFunc, options ...DecodeOption) error {
+	files, err := fs.Glob(fsys, pattern)
+	if err != nil {
+		return err
+	}
+	for _, file := range files {
+		f, err := fsys.Open(file)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		if err := DecodeEach(ctx, f, handlerFn, options...); err != nil {
+			return err
+		}
+		if err := f.Close(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// DecodeAllFiles  resolves files at the filesystem matching the pattern, decoding JSON or YAML files. Supports multi-document files.
+// Falls back to the unstructured.Unstructured type if a matching type cannot be found for the Kind.
+// Options may be provided to configure the behavior of the decoder.
+func DecodeAllFiles(ctx context.Context, fsys fs.FS, pattern string, options ...DecodeOption) ([]k8s.Object, error) {
+	objects := []k8s.Object{}
+	err := DecodeEachFile(ctx, fsys, pattern, func(ctx context.Context, obj k8s.Object) error {
+		objects = append(objects, obj)
+		return nil
+	}, options...)
+	return objects, err
+}
+
+// Decode a stream of documents of any Kind using either the innate typing of the scheme.
+// Falls back to the unstructured.Unstructured type if a matching type cannot be found for the Kind.
+//
+// If handlerFn returns an error, decoding is halted.
+// Options may be provided to configure the behavior of the decoder.
+func DecodeEach(ctx context.Context, manifest io.Reader, handlerFn HandlerFunc, options ...DecodeOption) error {
+	decoder := yaml.NewYAMLReader(bufio.NewReader(manifest))
+	for {
+		b, err := decoder.Read()
+		if errors.Is(err, io.EOF) {
+			break
+		} else if err != nil {
+			return err
+		}
+		obj, err := DecodeAny(bytes.NewReader(b), options...)
+		if err != nil {
+			return err
+		}
+		if err := handlerFn(ctx, obj); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Decode a stream of  documents of any Kind using either the innate typing of the scheme.
+// Falls back to the unstructured.Unstructured type if a matching type cannot be found for the Kind.
+// Options may be provided to configure the behavior of the decoder.
+func DecodeAll(ctx context.Context, manifest io.Reader, options ...DecodeOption) ([]k8s.Object, error) {
+	objects := []k8s.Object{}
+	err := DecodeEach(ctx, manifest, func(ctx context.Context, obj k8s.Object) error {
+		objects = append(objects, obj)
+		return nil
+	}, options...)
+	return objects, err
+}
+
+// Decode any single-document YAML or JSON input using either the innate typing of the scheme.
+// Falls back to the unstructured.Unstructured type if a matching type cannot be found for the Kind.
+// Options may be provided to configure the behavior of the decoder.
+func DecodeAny(manifest io.Reader, options ...DecodeOption) (k8s.Object, error) {
+	decodeOpt := &Options{}
+	for _, opt := range options {
+		opt(decodeOpt)
+	}
+
+	k8sDecoder := serializer.NewCodecFactory(scheme.Scheme).UniversalDeserializer().Decode
+	b, err := io.ReadAll(manifest)
+	if err != nil {
+		return nil, err
+	}
+	runtimeObj, _, err := k8sDecoder(b, decodeOpt.DefaultGVK, nil)
+	if runtime.IsNotRegisteredError(err) {
+		// fallback to the unstructured.Unstructured type if a type is not registered for the Object to be decoded
+		runtimeObj = &unstructured.Unstructured{}
+		if err := yaml.Unmarshal(b, runtimeObj); err != nil {
+			return nil, err
+		}
+	} else if err != nil {
+		return nil, err
+	}
+	obj, ok := runtimeObj.(k8s.Object)
+	if !ok {
+		return nil, err
+	}
+	for _, patch := range decodeOpt.MutateFuncs {
+		if err := patch(obj); err != nil {
+			return nil, err
+		}
+	}
+	return obj, nil
+}
+
+// Decode a single-document YAML or JSON file into the provided object. Patches are applied
+// after decoding to the object to update the loaded resource.
+func Decode(manifest io.Reader, obj k8s.Object, options ...DecodeOption) error {
+	decodeOpt := &Options{}
+	for _, opt := range options {
+		opt(decodeOpt)
+	}
+	if err := yaml.NewYAMLOrJSONDecoder(manifest, 1024).Decode(obj); err != nil {
+		return err
+	}
+	for _, patch := range decodeOpt.MutateFuncs {
+		if err := patch(obj); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// DecodeFile decodes a single-document YAML or JSON file into the provided object. Patches are applied
+// after decoding to the object to update the loaded resource.
+func DecodeFile(fsys fs.FS, manifestPath string, obj k8s.Object, options ...DecodeOption) error {
+	f, err := fsys.Open(manifestPath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return Decode(f, obj, options...)
+}
+
+// DecodeString decodes a single-document YAML or JSON string into the provided object. Patches are applied
+// after decoding to the object to update the loaded resource.
+func DecodeString(rawManifest string, obj k8s.Object, options ...DecodeOption) error {
+	return Decode(strings.NewReader(rawManifest), obj, options...)
+}
+
+// DefaultGVK instructs the decoder to use the given type to look up the appropriate Go type to decode into
+// instead of its default behavior of deciding this by decoding the Group, Version, and Kind fields.
+func DefaultGVK(defaults *schema.GroupVersionKind) DecodeOption {
+	return func(do *Options) {
+		do.DefaultGVK = defaults
+	}
+}
+
+// MutateOption can be used to add a custom MutateFunc to the DecodeOption
+// used to configure the decoding of objects
+func MutateOption(m MutateFunc) DecodeOption {
+	return func(do *Options) {
+		do.MutateFuncs = append(do.MutateFuncs, m)
+	}
+}
+
+// MutateLabels is an optional parameter to decoding functions that will patch an objects metadata.labels
+func MutateLabels(overrides map[string]string) DecodeOption {
+	return MutateOption(func(obj k8s.Object) error {
+		labels := obj.GetLabels()
+		if labels == nil {
+			labels = make(map[string]string)
+			obj.SetLabels(labels)
+		}
+		for key, value := range overrides {
+			labels[key] = value
+		}
+		return nil
+	})
+}
+
+// MutateAnnotations is an optional parameter to decoding functions that will patch an objects metadata.annotations
+func MutateAnnotations(overrides map[string]string) DecodeOption {
+	return MutateOption(func(obj k8s.Object) error {
+		annotations := obj.GetAnnotations()
+		if annotations == nil {
+			annotations = make(map[string]string)
+			obj.SetLabels(annotations)
+		}
+		for key, value := range overrides {
+			annotations[key] = value
+		}
+		return nil
+	})
+}
+
+// MutateOwnerAnnotations is an optional parameter to decoding functions that will patch objects using the given owner object
+func MutateOwnerAnnotations(owner k8s.Object) DecodeOption {
+	return MutateOption(func(obj k8s.Object) error {
+		return controllerutil.SetOwnerReference(owner, obj, scheme.Scheme)
+	})
+}
+
+// MutateNamespace is an optional parameter to decoding functions that will patch objects with the given namespace name
+func MutateNamespace(namespace string) DecodeOption {
+	return MutateOption(func(obj k8s.Object) error {
+		obj.SetNamespace(namespace)
+		return nil
+	})
+}
+
+// CreateHandler returns a HandlerFunc that will create objects
+func CreateHandler(r *resources.Resources, opts ...resources.CreateOption) HandlerFunc {
+	return func(ctx context.Context, obj k8s.Object) error {
+		return r.Create(ctx, obj, opts...)
+	}
+}
+
+// ReadHandler returns a HandlerFunc that will use the provided object's Kind / Namespace / Name to retrieve
+// the current state of the object using the provided Resource client.
+// This helper makes it easy to use a stale reference to an object to retrieve its current version.
+func ReadHandler(r *resources.Resources, handler HandlerFunc) HandlerFunc {
+	return func(ctx context.Context, obj k8s.Object) error {
+		name := obj.GetName()
+		namespace := obj.GetNamespace()
+		// use scheme.Scheme to generate a new, empty object to use as a base for decoding into
+		gvk := obj.GetObjectKind().GroupVersionKind()
+		o, err := scheme.Scheme.New(gvk)
+		if err != nil {
+			return fmt.Errorf("resources: GroupVersionKind not found in scheme: %s", gvk.String())
+		}
+		obj, ok := o.(k8s.Object)
+		if !ok {
+			return fmt.Errorf("resources: unexpected type %T does not satisfy k8s.Object", obj)
+		}
+		if err := r.Get(ctx, name, namespace, obj); err != nil {
+			return err
+		}
+		return handler(ctx, obj)
+	}
+}
+
+// UpdateHandler returns a HandlerFunc that will update objects
+func UpdateHandler(r *resources.Resources, opts ...resources.UpdateOption) HandlerFunc {
+	return func(ctx context.Context, obj k8s.Object) error {
+		return r.Update(ctx, obj, opts...)
+	}
+}
+
+// DeleteHandler returns a HandlerFunc that will delete objects
+func DeleteHandler(r *resources.Resources, opts ...resources.DeleteOption) HandlerFunc {
+	return func(ctx context.Context, obj k8s.Object) error {
+		return r.Delete(ctx, obj, opts...)
+	}
+}
+
+// IgnoreErrorHandler returns a HandlerFunc that will ignore the provided error if the errorMatcher returns true
+func IgnoreErrorHandler(handler HandlerFunc, errorMatcher func(err error) bool) HandlerFunc {
+	return func(ctx context.Context, obj k8s.Object) error {
+		if err := handler(ctx, obj); err != nil && !errorMatcher(err) {
+			return err
+		}
+		return nil
+	}
+}
+
+// NoopHandler returns a Handler func that only returns nil
+func NoopHandler(r *resources.Resources, opts ...resources.DeleteOption) HandlerFunc {
+	return func(ctx context.Context, obj k8s.Object) error {
+		return nil
+	}
+}
+
+// CreateIgnoreAlreadyExists returns a HandlerFunc that will create objects if they do not already exist
+func CreateIgnoreAlreadyExists(r *resources.Resources, opts ...resources.CreateOption) HandlerFunc {
+	return IgnoreErrorHandler(CreateHandler(r, opts...), apierrors.IsAlreadyExists)
+}
+
+// DeleteIgnoreNotFound returns a HandlerFunc that will delete objects if they do not already exist
+func DeleteIgnoreNotFound(r *resources.Resources, opts ...resources.CreateOption) HandlerFunc {
+	return IgnoreErrorHandler(CreateHandler(r, opts...), apierrors.IsNotFound)
+}

--- a/klient/decoder/decoder_test.go
+++ b/klient/decoder/decoder_test.go
@@ -1,0 +1,337 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package decoder
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/e2e-framework/klient/k8s"
+	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
+)
+
+const (
+	testLabel            = "labelvalue"
+	serviceAccountPrefix = "example-sa*"
+)
+
+func TestDecode(t *testing.T) {
+	testYAML := filepath.Join("testdata", "example-configmap-1.yaml")
+	f, err := os.Open(testYAML)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	cfg := v1.ConfigMap{}
+	if err := Decode(f, &cfg); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := cfg.Data["foo.cfg"]; !ok {
+		t.Fatal("key foo.cfg not found in decoded ConfigMap")
+	}
+}
+
+func TestDecodeUnstructuredCRD(t *testing.T) {
+	testYAML := filepath.Join("testdata", "fake-crd.yaml")
+	f, err := os.Open(testYAML)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	obj, err := DecodeAny(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	u, ok := obj.(*unstructured.Unstructured)
+	if !ok {
+		t.Fatalf("expected unstructured.Unstructured, got %T", u)
+	}
+
+	if _, ok := u.Object["spec"]; !ok {
+		t.Fatalf("spec field of CRD not found")
+	}
+
+	spec, ok := u.Object["spec"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("spec not expected map[string]interface{}, got: %T", u.Object["spec"])
+	}
+
+	example, ok := spec["example"].(string)
+	if !ok {
+		t.Fatalf("spec.example not expectedstring, got: %T", spec["example"])
+	}
+	if example != "value" {
+		t.Fatalf("spec.example not expected 'value', got %q", spec["example"])
+	}
+}
+
+func TestDecodeAny(t *testing.T) {
+	testYAML := filepath.Join("testdata", "example-configmap-3.json")
+	f, err := os.Open(testYAML)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	if obj, err := DecodeAny(f); err != nil {
+		t.Fatal(err)
+	} else if cfg, ok := obj.(*v1.ConfigMap); !ok && cfg.Data["foo.cfg"] != "" {
+		t.Fatal("key foo.cfg not found in decoded ConfigMap")
+	} else if _, ok := cfg.Data["foo.cfg"]; !ok {
+		t.Fatal("key foo.cfg not found in decoded ConfigMap")
+	}
+}
+
+func TestDecodeFile(t *testing.T) {
+	testYAML := "example-configmap-1.yaml"
+	testdata := os.DirFS("testdata")
+
+	cfg := v1.ConfigMap{}
+	if err := DecodeFile(testdata, testYAML, &cfg, MutateOption(func(o k8s.Object) error {
+		obj, ok := o.(*v1.ConfigMap)
+		if !ok {
+			t.Fatalf("unexpected type %T not ConfigMap", o)
+		}
+		if obj.ObjectMeta.Labels == nil {
+			obj.Labels = make(map[string]string)
+		}
+		obj.ObjectMeta.Labels["inject-value"] = "test123"
+		return nil
+	})); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.ObjectMeta.Labels["inject-value"] != "test123" {
+		t.Fatal("injected label value not found", cfg.ObjectMeta.Labels)
+	}
+	cfg = v1.ConfigMap{}
+	if err := DecodeFile(testdata, testYAML, &cfg, MutateLabels(map[string]string{"injected": testLabel})); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.ObjectMeta.Labels["injected"] != testLabel {
+		t.Fatal("injected label value not found", cfg.ObjectMeta.Labels)
+	}
+}
+
+func TestDecodeEachFile(t *testing.T) {
+	testdata := os.DirFS(filepath.Join("testdata", "examples"))
+
+	count := 0
+	if err := DecodeEachFile(context.TODO(), testdata, serviceAccountPrefix, func(ctx context.Context, obj k8s.Object) error {
+		count++
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	} else if expected := 3; count != expected {
+		t.Fatalf("expected %d objects, got: %d", expected, count)
+	}
+	// load `testdata/examples/*`
+	count = 0
+	serviceAccounts := 0
+	configs := 0
+	if err := DecodeEachFile(context.TODO(), testdata, "*", func(ctx context.Context, obj k8s.Object) error {
+		count++
+		switch obj.(type) {
+		case *v1.ConfigMap:
+			configs++
+		case *v1.ServiceAccount:
+			serviceAccounts++
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	} else if expected := 4; count != expected {
+		t.Fatalf("expected %d objects, got: %d", expected, count)
+	} else if expected := 3; expected != serviceAccounts {
+		t.Fatalf("expected %d serviceAccounts got %d", expected, serviceAccounts)
+	} else if expected := 1; expected != configs {
+		t.Fatalf("expected %d configs got %d", expected, configs)
+	}
+}
+
+func TestDecodeAllFiles(t *testing.T) {
+	// load `testdata/examples/example-sa*`
+	testdata := os.DirFS(filepath.Join("testdata", "examples"))
+	if objects, err := DecodeAllFiles(context.TODO(), testdata, serviceAccountPrefix); err != nil {
+		t.Fatal(err)
+	} else if expected, got := 3, len(objects); got != expected {
+		t.Fatalf("expected %d objects, got: %d", expected, got)
+	}
+	// load `testdata/examples/*`
+	if objects, err := DecodeAllFiles(context.TODO(), testdata, "*"); err != nil {
+		t.Fatal(err)
+	} else if expected, got := 4, len(objects); got != expected {
+		t.Fatalf("expected %d objects, got: %d", expected, got)
+	}
+}
+
+func TestDecodeEach(t *testing.T) {
+	testYAML := filepath.Join("testdata", "example-multidoc-1.yaml")
+	f, err := os.Open(testYAML)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	count := 0
+	err = DecodeEach(context.TODO(), f, func(ctx context.Context, obj k8s.Object) error {
+		count++
+		switch cfg := obj.(type) {
+		case *v1.ConfigMap:
+			if _, ok := cfg.Data["foo"]; !ok {
+				t.Fatalf("expected key 'foo' in ConfigMap.Data, got: %v", cfg.Data)
+			}
+		default:
+			t.Fatalf("unexpected type returned not ConfigMap: %T", cfg)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	} else if count != 2 {
+		t.Fatalf("expected 2 documents, got: %d", count)
+	}
+}
+
+func TestDecodeAll(t *testing.T) {
+	testYAML := filepath.Join("testdata", "example-multidoc-1.yaml")
+	f, err := os.Open(testYAML)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	if objects, err := DecodeAll(context.TODO(), f); err != nil {
+		t.Fatal(err)
+	} else if expected, got := 2, len(objects); got != expected {
+		t.Fatalf("expected 2 documents, got: %d", got)
+	}
+}
+
+func TestDecodersWithMutateFunc(t *testing.T) {
+	t.Run("DecodeAny", func(t *testing.T) {
+		testYAML := filepath.Join("testdata", "example-configmap-3.json")
+		f, err := os.Open(testYAML)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer f.Close()
+		if obj, err := DecodeAny(f, MutateLabels(map[string]string{"injected": testLabel})); err != nil {
+			t.Fatal(err)
+		} else if cfg, ok := obj.(*v1.ConfigMap); !ok && cfg.Data["foo.cfg"] != "" {
+			t.Fatal("key foo.cfg not found in decoded ConfigMap")
+		} else if cfg.ObjectMeta.Labels["injected"] != testLabel {
+			t.Fatal("injected label value not found", cfg.ObjectMeta.Labels)
+		}
+	})
+	t.Run("DecodeEach", func(t *testing.T) {
+		testdata := os.DirFS(filepath.Join("testdata", "examples"))
+		if err := DecodeEachFile(context.TODO(), testdata, serviceAccountPrefix, func(ctx context.Context, obj k8s.Object) error {
+			if labels := obj.GetLabels(); labels["injected"] != testLabel {
+				t.Fatalf("unexpected value in labels: %q", labels["injected"])
+			}
+			return nil
+		}, MutateLabels(map[string]string{"injected": testLabel})); err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
+func TestHandlerFuncs(t *testing.T) {
+	handlerNS := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "handler-test"}}
+	res, err := resources.New(cfg)
+	if err != nil {
+		t.Fatalf("Error creating new resources object: %v", err)
+	}
+	err = res.Create(context.TODO(), handlerNS)
+	if err != nil {
+		t.Fatalf("error while creating namespace %q: %s", handlerNS.Name, err)
+	}
+	testdata := os.DirFS(filepath.Join("testdata", "examples"))
+	patches := []DecodeOption{MutateNamespace(handlerNS.Name), MutateLabels(map[string]string{"injected": testLabel})}
+	// lookup all objects to use for verification / deletion steps later on
+	objects, err := DecodeAllFiles(context.TODO(), testdata, "*", patches...)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("DecodeEach_Create", func(t *testing.T) {
+		if err := DecodeEachFile(context.TODO(), testdata, "*", CreateHandler(res), patches...); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("DecodeEach_ReadHandler", func(t *testing.T) {
+		count := 0
+		serviceAccounts := 0
+		configs := 0
+		if err := DecodeEachFile(context.TODO(), testdata, "*", ReadHandler(res, func(ctx context.Context, obj k8s.Object) error {
+			if labels := obj.GetLabels(); labels["injected"] != testLabel {
+				t.Fatalf("unexpected value in labels: %q", labels["injected"])
+			} else {
+				count++
+				switch cfg := obj.(type) {
+				case *v1.ConfigMap:
+					if _, ok := cfg.Data["foo.cfg"]; !ok {
+						t.Fatalf("expected key 'foo.cfg' in ConfigMap.Data, got: %v", cfg.Data)
+					}
+					configs++
+				case *v1.ServiceAccount:
+					serviceAccounts++
+				default:
+					t.Fatalf("unexpected type returned not ConfigMap: %T", cfg)
+				}
+			}
+			return nil
+		}), MutateNamespace(handlerNS.Name)); err != nil {
+			t.Fatal(err)
+		}
+
+		if expected := 4; count != expected {
+			t.Fatalf("expected %d objects, got: %d", expected, count)
+		} else if expected := 3; expected != serviceAccounts {
+			t.Fatalf("expected %d serviceAccounts got %d", expected, serviceAccounts)
+		} else if expected := 1; expected != configs {
+			t.Fatalf("expected %d configs got %d", expected, configs)
+		}
+	})
+
+	t.Run("DecodeEach_Delete", func(t *testing.T) {
+		if err := DecodeEachFile(context.TODO(), testdata, "*", DeleteHandler(res), patches...); err != nil {
+			t.Fatal(err)
+		}
+
+		t.Run("Verify", func(t *testing.T) {
+			count := 0
+			for i := range objects {
+				if err := IgnoreErrorHandler(ReadHandler(res, func(ctx context.Context, obj k8s.Object) error {
+					t.Logf("Object { apiVersion: %q; Kind:%q; Namespace:%q; Name:%q } found", obj.GetObjectKind().GroupVersionKind().Version, obj.GetObjectKind().GroupVersionKind().Kind, obj.GetNamespace(), obj.GetName())
+					count++
+					return nil
+				}), apierrors.IsNotFound)(ctx, objects[i]); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if count > 0 {
+				t.Fatalf("%d test objects were not deleted", count)
+			}
+		})
+	})
+}

--- a/klient/decoder/main_test.go
+++ b/klient/decoder/main_test.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package decoder
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	"sigs.k8s.io/e2e-framework/klient/internal/testutil"
+)
+
+var (
+	tc        *testutil.TestCluster
+	clientset kubernetes.Interface
+	ctx       = context.TODO()
+	cfg       *rest.Config
+)
+
+func TestMain(m *testing.M) {
+	tc = testutil.SetupTestCluster("")
+	clientset = tc.Clientset
+	cfg = tc.RESTConfig
+	code := m.Run()
+	teardown()
+	os.Exit(code)
+}
+
+func teardown() {
+	tc.DestroyTestCluster()
+}

--- a/klient/decoder/testdata/example-configmap-1.yaml
+++ b/klient/decoder/testdata/example-configmap-1.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: example-1
+data:
+  foo.cfg: |
+    foo: bar

--- a/klient/decoder/testdata/example-configmap-3.json
+++ b/klient/decoder/testdata/example-configmap-3.json
@@ -1,0 +1,10 @@
+{
+    "apiVersion": "v1",
+    "kind": "ConfigMap",
+    "metadata": {
+      "name": "example-3"
+    },
+    "data": {
+      "foo.cfg": "foo: bar3\n"
+    }
+}

--- a/klient/decoder/testdata/example-multidoc-1.yaml
+++ b/klient/decoder/testdata/example-multidoc-1.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: example-4
+  labels:
+    example: four
+data:
+  foo: |
+    foo: bar
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: example-5
+data:
+  foo: |
+    foo: bar

--- a/klient/decoder/testdata/examples/example-configmap-2.yaml
+++ b/klient/decoder/testdata/examples/example-configmap-2.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: example-2
+data:
+  foo.cfg: |
+    foo: bar2

--- a/klient/decoder/testdata/examples/example-sa-1.yaml
+++ b/klient/decoder/testdata/examples/example-sa-1.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: example-1

--- a/klient/decoder/testdata/examples/example-sa-2.yml
+++ b/klient/decoder/testdata/examples/example-sa-2.yml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: example-2

--- a/klient/decoder/testdata/examples/example-sa-3.json
+++ b/klient/decoder/testdata/examples/example-sa-3.json
@@ -1,0 +1,7 @@
+{
+    "apiVersion": "v1",
+    "kind": "ServiceAccount",
+    "metadata": {
+      "name": "example-3"
+    }
+}

--- a/klient/decoder/testdata/fake-crd.yaml
+++ b/klient/decoder/testdata/fake-crd.yaml
@@ -1,0 +1,7 @@
+apiVersion: mycrd.domain.com/v1alpha1
+kind: MyType
+metadata:
+  name: example-fake-instance
+  namespace: example
+spec:
+  example: value


### PR DESCRIPTION
This was created to solve for #43 based on some common patterns from my kubebuilder codebase that I am adapting to this framework.

After I started to write the tests and validate JSON functionality, the naming of the package and the functions became outdated.

Should this functionality move inside one of the existing packages -- e.g. `resources`?