### PR TITLE
Add *testing.T to before/after feature hooks

### DIFF
--- a/pkg/env/action.go
+++ b/pkg/env/action.go
@@ -71,7 +71,7 @@ func (a *action) runWithT(ctx context.Context, cfg *envconf.Config, t *testing.T
 }
 
 // runWithFeature will run the action and inject a FeatureInfo object into the callback function.
-func (a *action) runWithFeature(ctx context.Context, cfg *envconf.Config, fi types.Feature) (context.Context, error) {
+func (a *action) runWithFeature(ctx context.Context, cfg *envconf.Config, t *testing.T, fi types.Feature) (context.Context, error) {
 	switch a.role {
 	case roleBeforeFeature, roleAfterFeature:
 		for _, f := range a.featureFuncs {
@@ -80,7 +80,7 @@ func (a *action) runWithFeature(ctx context.Context, cfg *envconf.Config, fi typ
 			}
 
 			var err error
-			ctx, err = f(ctx, cfg, fi)
+			ctx, err = f(ctx, cfg, t, fi)
 			if err != nil {
 				return ctx, err
 			}

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -202,7 +202,7 @@ func (e *testEnv) processTestFeature(t *testing.T, featureName string, feature t
 	afterFeatureActions := e.getAfterFeatureActions()
 
 	for _, action := range beforeFeatureActions {
-		if e.ctx, err = action.runWithFeature(e.ctx, e.cfg, deepCopyFeature(feature)); err != nil {
+		if e.ctx, err = action.runWithFeature(e.ctx, e.cfg, t, deepCopyFeature(feature)); err != nil {
 			t.Fatalf("BeforeEachTest failure: %s", err)
 		}
 	}
@@ -212,7 +212,7 @@ func (e *testEnv) processTestFeature(t *testing.T, featureName string, feature t
 
 	// execute beforeFeature actions
 	for _, action := range afterFeatureActions {
-		if e.ctx, err = action.runWithFeature(e.ctx, e.cfg, deepCopyFeature(feature)); err != nil {
+		if e.ctx, err = action.runWithFeature(e.ctx, e.cfg, t, deepCopyFeature(feature)); err != nil {
 			t.Fatalf("BeforeEachTest failure: %s", err)
 		}
 	}

--- a/pkg/env/env_test.go
+++ b/pkg/env/env_test.go
@@ -400,10 +400,10 @@ func TestEnv_Test(t *testing.T) {
 			setup: func(t *testing.T, ctx context.Context) []string {
 				env := newTestEnv()
 				val := []string{}
-				env.BeforeEachFeature(func(ctx context.Context, _ *envconf.Config, info features.Feature) (context.Context, error) {
+				env.BeforeEachFeature(func(ctx context.Context, _ *envconf.Config, _ *testing.T, info features.Feature) (context.Context, error) {
 					val = append(val, "before-each-feature")
 					return ctx, nil
-				}).AfterEachFeature(func(ctx context.Context, _ *envconf.Config, info features.Feature) (context.Context, error) {
+				}).AfterEachFeature(func(ctx context.Context, _ *envconf.Config, _ *testing.T, info features.Feature) (context.Context, error) {
 					val = append(val, "after-each-feature")
 					return ctx, nil
 				})
@@ -433,7 +433,7 @@ func TestEnv_Test(t *testing.T) {
 			setup: func(t *testing.T, ctx context.Context) []string {
 				env := newTestEnv()
 				val := []string{}
-				env.BeforeEachFeature(func(ctx context.Context, _ *envconf.Config, info features.Feature) (context.Context, error) {
+				env.BeforeEachFeature(func(ctx context.Context, _ *envconf.Config, _ *testing.T, info features.Feature) (context.Context, error) {
 					val = append(val, "before-each-feature")
 					t.Logf("%#v, len(steps)=%v step[0].Name: %v\n", info, len(info.Steps()), info.Steps()[0].Name())
 
@@ -452,7 +452,7 @@ func TestEnv_Test(t *testing.T) {
 					labelMap := info.Labels()
 					labelMap["foo"] = "bar"
 					return ctx, nil
-				}).AfterEachFeature(func(ctx context.Context, _ *envconf.Config, info features.Feature) (context.Context, error) {
+				}).AfterEachFeature(func(ctx context.Context, _ *envconf.Config, _ *testing.T, info features.Feature) (context.Context, error) {
 					val = append(val, "after-each-feature")
 					t.Logf("%#v, len(steps)=%v\n", info, len(info.Steps()))
 					if info.Labels()["foo"] == "bar" {
@@ -549,13 +549,13 @@ func TestTestEnv_TestInParallel(t *testing.T) {
 		return ctx, nil
 	})
 
-	env.BeforeEachFeature(func(ctx context.Context, config *envconf.Config, feature types.Feature) (context.Context, error) {
+	env.BeforeEachFeature(func(ctx context.Context, config *envconf.Config, _ *testing.T, feature types.Feature) (context.Context, error) {
 		t.Logf("Running before each feature for feature %s", feature.Name())
 		beforeFeatureCount++
 		return ctx, nil
 	})
 
-	env.AfterEachFeature(func(ctx context.Context, config *envconf.Config, feature types.Feature) (context.Context, error) {
+	env.AfterEachFeature(func(ctx context.Context, config *envconf.Config, _ *testing.T, feature types.Feature) (context.Context, error) {
 		t.Logf("Running after each feature for feature %s", feature.Name())
 		afterFeatureCount++
 		return ctx, nil

--- a/pkg/internal/types/types.go
+++ b/pkg/internal/types/types.go
@@ -33,7 +33,9 @@ type EnvFunc func(context.Context, *envconf.Config) (context.Context, error)
 // can be used to customized the behavior of the
 // environment. Changes to context are expected to surface
 // to caller. Meant for use with before/after feature hooks.
-type FeatureEnvFunc func(context.Context, *envconf.Config, Feature) (context.Context, error)
+// *testing.T is provided in order to provide pass/fail context to
+// features.
+type FeatureEnvFunc func(context.Context, *envconf.Config, *testing.T, Feature) (context.Context, error)
 
 // TestEnvFunc represents a user-defined operation that
 // can be used to customized the behavior of the


### PR DESCRIPTION
In order to get test pass/fail information in these hooks
we need access to the testing object.

Fixes #101 

** NOTE **
I wanted to add a test for this but the problem is that it passes the testing.T object around so even when we get the expected behavior, when we fail the test and confirm it cascades, there is no way to avoid `go test` from still counting that as a failure.

The workaround for this would be to make a mock that implements `testing.TB` and use that, but our signatures everywhere use *testing.T explicitly so that wont work.

Manually confirmed it did cascade though.

Signed-off-by: John Schnake <jschnake@vmware.com>