### PR TITLE
GIT-119: handle scoping for parallel tests

### DIFF
--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -243,18 +243,19 @@ func (e *testEnv) processTests(t *testing.T, enableParallelRun bool, testFeature
 
 	var wg sync.WaitGroup
 	for i, feature := range testFeatures {
+		featureCopy := feature
 		featName := feature.Name()
 		if featName == "" {
 			featName = fmt.Sprintf("Feature-%d", i+1)
 		}
 		if runInParallel {
 			wg.Add(1)
-			go func(w *sync.WaitGroup) {
+			go func(w *sync.WaitGroup, featName string, f types.Feature) {
 				defer w.Done()
-				e.processTestFeature(t, featName, feature)
-			}(&wg)
+				e.processTestFeature(t, featName, f)
+			}(&wg, featName, featureCopy)
 		} else {
-			e.processTestFeature(t, featName, feature)
+			e.processTestFeature(t, featName, featureCopy)
 		}
 	}
 	if runInParallel {

--- a/support/kind/kind.go
+++ b/support/kind/kind.go
@@ -29,7 +29,7 @@ import (
 	"github.com/vladimirvivien/gexe"
 )
 
-var kindVersion = "v0.11.0"
+var kindVersion = "v0.12.0"
 
 type Cluster struct {
 	name        string
@@ -154,7 +154,7 @@ func (k *Cluster) Destroy() error {
 
 func (k *Cluster) findOrInstallKind(e *gexe.Echo) error {
 	if e.Prog().Avail("kind") == "" {
-		log.V(4).Infof(`kind not found, installing with GO111MODULE="on" go get sigs.k8s.io/kind@%s`, kindVersion)
+		log.V(4).Infof(`kind not found, installing with go install sigs.k8s.io/kind@%s`, kindVersion)
 		if err := k.installKind(e); err != nil {
 			return err
 		}
@@ -167,8 +167,8 @@ func (k *Cluster) installKind(e *gexe.Echo) error {
 		kindVersion = k.version
 	}
 
-	log.V(4).Infof("Installing: go get sigs.k8s.io/kind@%s", kindVersion)
-	p := e.SetEnv("GO111MODULE", "on").RunProc(fmt.Sprintf("go get sigs.k8s.io/kind@%s", kindVersion))
+	log.V(4).Infof("Installing: go install sigs.k8s.io/kind@%s", kindVersion)
+	p := e.RunProc(fmt.Sprintf("go install sigs.k8s.io/kind@%s", kindVersion))
 	if p.Err() != nil {
 		return fmt.Errorf("failed to install kind: %s", p.Err())
 	}


### PR DESCRIPTION
Closes #119 

```bash
❯ go test -v . -args --parallel
I0316 19:26:00.910966   58073 parallel_features_test.go:46] "Args" flag=&{client:<nil> kubeconfig: namespace: assessmentRegex:<nil> featureRegex:<nil> labels:map[] skipFeatureRegex:<nil> skipLabels:map[] skipAssessmentRegex:<nil> parallelTests:true}
=== RUN   TestPodBringUp
=== RUN   TestPodBringUp/Feature_Two
=== RUN   TestPodBringUp/Feature_Two/Create_Nginx_Deployment_2
=== RUN   TestPodBringUp/Feature_One
=== RUN   TestPodBringUp/Feature_One/Create_Nginx_Deployment_1
=== RUN   TestPodBringUp/Feature_Two/Wait_for_Nginx_Deployment_2_to_be_scaled_up
=== RUN   TestPodBringUp/Feature_One/Wait_for_Nginx_Deployment_1_to_be_scaled_up
--- PASS: TestPodBringUp (65.08s)
    --- PASS: TestPodBringUp/Feature_Two (65.05s)
        --- PASS: TestPodBringUp/Feature_Two/Create_Nginx_Deployment_2 (0.04s)
        --- PASS: TestPodBringUp/Feature_Two/Wait_for_Nginx_Deployment_2_to_be_scaled_up (65.01s)
    --- PASS: TestPodBringUp/Feature_One (65.07s)
        --- PASS: TestPodBringUp/Feature_One/Create_Nginx_Deployment_1 (0.07s)
        --- PASS: TestPodBringUp/Feature_One/Wait_for_Nginx_Deployment_1_to_be_scaled_up (65.01s)
PASS
ok  	sigs.k8s.io/e2e-framework/examples/parallel_features	331.487s
```

Closes #122 as well 