### PR TITLE
Update test-harness-framework.md

### DIFF
--- a/docs/design/test-harness-framework.md
+++ b/docs/design/test-harness-framework.md
@@ -350,7 +350,7 @@ func TestMain(m *testing.M) {
     })
 
     env.Finish(func(ctx context.Context, cfg envconf.Config) (context.Context, error){
-        // setup environment
+        // teardown environment
         return ctx, nil
     })
     ...


### PR DESCRIPTION
Found a small typo in the docs. I assume it was meant `teardown` rather than `setup` for the `.Finish()` callback.