### PR TITLE
Support for Helm uninstall

### DIFF
--- a/third_party/helm/helm.go
+++ b/third_party/helm/helm.go
@@ -197,7 +197,7 @@ func (m *Manager) RunInstall(opts ...Option) error {
 // RunUninstall provides a way to uninstall the specified helm chart (useful in teardowns etc...)
 func (m *Manager) RunUninstall(opts ...Option) error {
 	o := m.processOpts(opts...)
-	o.mode = "install"
+	o.mode = "uninstall"
 	return m.run(o)
 }
 

--- a/third_party/helm/helm.go
+++ b/third_party/helm/helm.go
@@ -194,6 +194,13 @@ func (m *Manager) RunInstall(opts ...Option) error {
 	return m.run(o)
 }
 
+// RunUninstall provides a way to uninstall the specified helm chart (useful in teardowns etc...)
+func (m *Manager) RunUninstall(opts ...Option) error {
+	o := m.processOpts(opts...)
+	o.mode = "install"
+	return m.run(o)
+}
+
 // RunTemplate provides a way to invoke the `helm template` commands that can be used
 // to perform the basic sanity check on the charts to make sure if the charts can be
 // rendered successfully or not.


### PR DESCRIPTION
I'm using this in teardowns when running against a K8s cluster that keeps on living after the test execution.

I think it may be useful to others and I don't see the harm on having it there, what do you think?