### PR TITLE
docs(readme): fix test example

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ func TestKubernetes(t *testing.T) {
     f2 := features.New("count namespaces").
         WithLabel("type", "ns-count").
         Assess("namespace exist", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-            var nspaces corev1.Namespace
+            var nspaces corev1.NamespaceList
             err := cfg.Client().Resources().List(context.TODO(), &nspaces)
             if err != nil {
                 t.Fatal(err)
@@ -93,7 +93,7 @@ func TestKubernetes(t *testing.T) {
         }).Feature()
         
     // test feature
-    testenv.Test(f1, f2)
+    testenv.Test(t, f1, f2)
 }
 ```
 #### Running the test


### PR DESCRIPTION
Fix compiling errors in test function example from readme.

* nspaces should be `corev1.NamespaceList` type
* testenv.Test signature is `Test(*testing.T, ...Feature)`, so t should be first arg