### PR TITLE
examples/wait_for_resources: fix Go code indentation in README

### DIFF
--- a/examples/wait_for_resources/README.md
+++ b/examples/wait_for_resources/README.md
@@ -21,8 +21,8 @@ Additionally, it is easy to wait for changes to any resource type with the `Reso
 
 ```go
 func TestResourceMatch(t *testing.T) {
-    ...
-    deployment := appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "deploy-name"}}
+	...
+	deployment := appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "deploy-name"}}
 	err = wait.For(conditions.New(client.Resources()).ResourceMatch(deployment, func(object k8s.Object) bool {
 		d := object.(*appsv1.Deployment)
 		return d.Status.AvailableReplicas == 2 && d.Status.ReadyReplicas == 2
@@ -40,7 +40,7 @@ It is common to need to check for the existence of a set of objects by name:
 
 ```go
 func TestResourcesFound(t *testing.T) {
-    ...
+	...
 	pods := &v1.PodList{
 		Items: []v1.Pod{
 			{ObjectMeta: metav1.ObjectMeta{Name: "p9", Namespace: namespace}},
@@ -48,7 +48,7 @@ func TestResourcesFound(t *testing.T) {
 			{ObjectMeta: metav1.ObjectMeta{Name: "p11", Namespace: namespace}},
 		},
 	}
-    // wait for the set of pods to exist
+	// wait for the set of pods to exist
 	err = wait.For(conditions.New(client.Resources()).ResourcesFound(pods))
 	if err != nil {
 		t.Error(err)
@@ -61,14 +61,14 @@ Or to check for their absence:
 
 ```go
 func TestResourcesDeleted(t *testing.T) {
-    ...
+	...
 	pods := &v1.PodList{}
-    // wait for 1 pod with the label `"app": "d5"`
+	// wait for 1 pod with the label `"app": "d5"`
 	err = wait.For(conditions.New(client.Resources()).ResourceListN(
-        pods,
-        1, 
-        resources.WithLabelSelector(labels.FormatLabels(map[string]string{"app": "d5"}))),
-    )
+		pods,
+		1,
+		resources.WithLabelSelector(labels.FormatLabels(map[string]string{"app": "d5"}))),
+	)
 	if err != nil {
 		t.Error(err)
 	}
@@ -76,11 +76,11 @@ func TestResourcesDeleted(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-    // wait for the set of pods to finish deleting
+	// wait for the set of pods to finish deleting
 	err = wait.For(conditions.New(client.Resources()).ResourcesDeleted(pods))
 	if err != nil {
 		t.Error(err)
 	}
-    ...
+	...
 }
 ```


### PR DESCRIPTION
Consistently use tabs to indent, so the code examples are rendered with
consistent indentation.