### PR TITLE
controller-runtime: enable ability to fetch controller runtime client

### DIFF
--- a/klient/client.go
+++ b/klient/client.go
@@ -17,7 +17,9 @@ limitations under the License.
 package klient
 
 import (
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
+	cr "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/e2e-framework/klient/conf"
 	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
 )
@@ -36,6 +38,12 @@ type Client interface {
 type client struct {
 	cfg       *rest.Config
 	resources *resources.Resources
+}
+
+// NewControllerRuntimeClient provides an instance of the Controller runtime client with
+// the provided rest config and custom runtime scheme.
+func NewControllerRuntimeClient(cfg *rest.Config, scheme *runtime.Scheme) (cr.Client, error) {
+	return cr.New(cfg, cr.Options{Scheme: scheme})
 }
 
 // New returns a new Client value

--- a/klient/k8s/resources/resources.go
+++ b/klient/k8s/resources/resources.go
@@ -189,6 +189,11 @@ func (r *Resources) GetScheme() *runtime.Scheme {
 	return r.scheme
 }
 
+// GetClient return the controller-runtime client instance
+func (r *Resources) GetControllerRuntimeClient() cr.Client {
+	return r.client
+}
+
 func (r *Resources) Watch(object k8s.ObjectList, opts ...ListOption) *watcher.EventHandlerFuncs {
 	listOptions := &metav1.ListOptions{}
 


### PR DESCRIPTION
## What does this do ?
Enable the ability to fetch the reusable controller-runtime client via the `e2e-framework` infra. 

## Why is this required?
https://github.com/kubernetes-sigs/e2e-framework/issues/146#issuecomment-1177699723 Has a good explanation on the usability of this features. 

Fixes #146 


