### PR TITLE
build: fix golangci-lint SA1019 io/ioutil

### DIFF
--- a/klient/conf/main_test.go
+++ b/klient/conf/main_test.go
@@ -18,7 +18,6 @@ package conf
 
 import (
 	"flag"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -77,7 +76,7 @@ func setup() {
 }
 
 func createFile(path, data string) error {
-	return ioutil.WriteFile(path, []byte(data), 0o644)
+	return os.WriteFile(path, []byte(data), 0o644)
 }
 
 // genKubeconfig used to genearte kube config file

--- a/support/kind/kind.go
+++ b/support/kind/kind.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -63,7 +62,7 @@ func (k *Cluster) getKubeconfig() (string, error) {
 		return "", fmt.Errorf("kind get kubeconfig: %s: %w", p.Result(), p.Err())
 	}
 
-	file, err := ioutil.TempFile("", fmt.Sprintf("kind-cluser-%s", kubecfg))
+	file, err := os.CreateTemp("", fmt.Sprintf("kind-cluser-%s", kubecfg))
 	if err != nil {
 		return "", fmt.Errorf("kind kubeconfig file: %w", err)
 	}


### PR DESCRIPTION
Replacing usages of `io/ioutil` with its recommendations should fix https://github.com/kubernetes-sigs/e2e-framework/issues/159 .

I hope this is in your interest 😃 