### PR TITLE
Fix log output on errors during test lifecycle actions

### DIFF
--- a/pkg/env/action.go
+++ b/pkg/env/action.go
@@ -26,14 +26,35 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/internal/types"
 )
 
+type actionRole uint8
+
 const (
-	roleSetup = iota
+	roleSetup actionRole = iota
 	roleBeforeTest
 	roleBeforeFeature
 	roleAfterFeature
 	roleAfterTest
 	roleFinish
 )
+
+func (r actionRole) String() string {
+	switch r {
+	case roleSetup:
+		return "Setup"
+	case roleBeforeTest:
+		return "BeforeEachTest"
+	case roleBeforeFeature:
+		return "BeforeEachFeature"
+	case roleAfterFeature:
+		return "AfterEachFeature"
+	case roleAfterTest:
+		return "AfterEachTest"
+	case roleFinish:
+		return "Finish"
+	default:
+		panic("unknown role") // this should never happen
+	}
+}
 
 // action a group env functions
 type action struct {

--- a/pkg/env/action_test.go
+++ b/pkg/env/action_test.go
@@ -104,3 +104,59 @@ func TestAction_Run(t *testing.T) {
 		})
 	}
 }
+
+func TestActionRole_String(t *testing.T) {
+	tests := []struct {
+		name string
+		r    actionRole
+		want string
+	}{
+		{
+			name: "RoleSetup",
+			r:    roleSetup,
+			want: "Setup",
+		},
+		{
+			name: "RoleBeforeTest",
+			r:    roleBeforeTest,
+			want: "BeforeEachTest",
+		},
+		{
+			name: "RoleBeforeFeature",
+			r:    roleBeforeFeature,
+			want: "BeforeEachFeature",
+		},
+		{
+			name: "RoleAfterEachFeature",
+			r:    roleAfterFeature,
+			want: "AfterEachFeature",
+		},
+		{
+			name: "RoleAfterTest",
+			r:    roleAfterTest,
+			want: "AfterEachTest",
+		},
+		{
+			name: "RoleFinish",
+			r:    roleFinish,
+			want: "Finish",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := test.r.String(); got != test.want {
+				t.Errorf("String() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestActionRole_String_Unknown(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("Unknown ActionRole should panic")
+		}
+	}()
+
+	actionRole(100).String()
+}

--- a/pkg/env/action_test.go
+++ b/pkg/env/action_test.go
@@ -158,5 +158,5 @@ func TestActionRole_String_Unknown(t *testing.T) {
 		}
 	}()
 
-	actionRole(100).String()
+	_ = actionRole(100).String()
 }


### PR DESCRIPTION
Hi

This change should fix https://github.com/kubernetes-sigs/e2e-framework/issues/161 by logging the correct action role as prefix when failing during a test lifecycle action.

Thanks for having a look in advance & keep up the good work!