### PR TITLE
chore: bump vladimirvivien/gexe to v0.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module sigs.k8s.io/e2e-framework
 go 1.18
 
 require (
-	github.com/vladimirvivien/gexe v0.1.1
+	github.com/vladimirvivien/gexe v0.2.0
 	k8s.io/api v0.24.1
 	k8s.io/apimachinery v0.24.1
 	k8s.io/client-go v0.24.1

--- a/go.sum
+++ b/go.sum
@@ -254,8 +254,8 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/vladimirvivien/gexe v0.1.1 h1:2A0SBaOSKH+cwLVdt6H+KkHZotZWRNLlWygANGw5DxE=
-github.com/vladimirvivien/gexe v0.1.1/go.mod h1:LHQL00w/7gDUKIak24n801ABp8C+ni6eBht9vGVst8w=
+github.com/vladimirvivien/gexe v0.2.0 h1:nbdAQ6vbZ+ZNsolCgSVb9Fno60kzSuvtzVh6Ytqi/xY=
+github.com/vladimirvivien/gexe v0.2.0/go.mod h1:LHQL00w/7gDUKIak24n801ABp8C+ni6eBht9vGVst8w=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/support/kind/kind.go
+++ b/support/kind/kind.go
@@ -54,8 +54,9 @@ func (k *Cluster) getKubeconfig() (string, error) {
 	if p.Err() != nil {
 		return "", fmt.Errorf("kind get kubeconfig: %w", p.Err())
 	}
+
 	var stdout bytes.Buffer
-	if _, err := stdout.ReadFrom(p.StdOut()); err != nil {
+	if _, err := stdout.ReadFrom(p.GetOutputPipe()); err != nil {
 		return "", fmt.Errorf("kind kubeconfig stdout bytes: %w", err)
 	}
 	if p.Wait().Err() != nil {


### PR DESCRIPTION
A new version of vladimirvivien/gexe has been released last night and we can't update to it since there's a little breaking change that needs to be fixed at first in the e2e-framework.

```
# sigs.k8s.io/e2e-framework/support/kind
../../../go/pkg/mod/sigs.k8s.io/e2e-framework@v0.0.8/support/kind/kind.go:58:33: p.StdOut undefined (type *"github.com/vladimirvivien/gexe/exec".Proc has no field or method StdOut)
```