### PR TITLE
Support for an e2e-framework kubetest2 tester

### DIFF
--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -63,6 +63,15 @@ func NewWithConfig(cfg *envconf.Config) types.Environment {
 	return env
 }
 
+// NewFromFlags creates a test environment using configuration values from CLI flags
+func NewFromFlags() (types.Environment, error) {
+	cfg, err := envconf.NewFromFlags()
+	if err != nil {
+		return nil, err
+	}
+	return NewWithConfig(cfg), nil
+}
+
 // NewWithKubeConfig creates an environment using an Environment Configuration value
 // and the given kubeconfig.
 func NewWithKubeConfig(kubeconfigfile string) types.Environment {

--- a/third_party/kubetest2/README.md
+++ b/third_party/kubetest2/README.md
@@ -1,0 +1,208 @@
+# Kubetest2 E2E-Framework Tester
+
+This third-party package implements a Kubernetes-SIGs/[kubetest2](https://github.com/kubernetes-sigs/kubetest2) tester capable of executing tests written using the [e2e-framework](https://github.com/kubernetes-sigs/e2e-framework).
+
+## Kubetest2 installation
+
+First, you must ensure that you have the `kubetest2` binary installed in the environment where you will run your tests :
+
+```
+go install sigs.k8s.io/kubetest2/...@latest
+```
+
+> See further detail [here](https://github.com/kubernetes-sigs/kubetest2#installation).
+
+## E2E-Framework installation
+
+To build the e2e-framework tester, you can use the following `go install` command:
+
+```
+go install sigs.k8s.io/e2e-framework/third_party/kubetest2/...@latest
+```
+
+Or, you can build from source:
+
+```
+go build ./cmd/kubetest2-tester-e2e-framework/
+```
+
+Either approach will produce a binary file named `kubetest2-tester-e2e-framework`, which follows a naming convention that the `kubetest2` binary will use to launch the e2e-framework tester. Next, add your built e2e-framework tester binary to your operating system's `PATH`.
+
+## Running the e2e-framework tester
+
+If the installation steps are successful, run the following to get information on how to run your tests with kubetest2 and the e2e-framewro:
+
+```
+$> kubetest2-tester-e2e-framework --help
+Usage: kubetest2-tester-e2e-framework [e2e-framework-flags]
+When used with kubetest2: kubetest2 [<deployer>] --test=e2e-framework -- [e2e-framework-flags]
+e2e-framework flags:
+      --assess string               Regular expression to select assessment(s) to run
+      --disable-graceful-teardown   Ignore panic recovery while running tests. This will prevent test finish steps from getting executed on panic
+      --dry-run                     Run Test suite in dry-run mode. This will list the tests to be executed without actually running them
+      --fail-fast                   Fail immediately and stop running untested code
+      --feature string              Regular expression to select feature(s) to test
+  -h, --help
+      --kubeconfig string           Path to a cluster kubeconfig file (optional)
+      --labels string               Comma-separated key=value to filter features by labels
+      --namespace string            A namespace value to use for testing (optional)
+      --packages string             Space-separated packages to test
+      --parallel                    Run test features in parallel
+      --skip-assessments string     Regular expression to skip assessment(s) to run
+      --skip-features string        Regular expression to skip feature(s) to run
+      --skip-labels string          Regular expression to skip label(s) to run
+      --test-flags string           Space-separated flags applied to 'go test' command
+```
+
+To run a test with kubetest2, you must follow this command format as outlined above:
+
+```
+kubetest2 [<deployer>] --test=e2e-framework -- [e2e-framework-flags]
+```
+
+Where:
+
+* `deployer` is a binary used to stand up an infrastructure (not provided here).
+* `--test=e2e-framework` specifies the tester to used, in this case the e2e-framework tester.
+* `e2e-framework-flags` are the list of CLI flags that are passed to the e2e-framework binary.
+
+### Running a simple tests
+
+Let us use `kubetest2` to run a simple test with no deployer and no arguments passed to the test:
+
+```
+kubetest2 noop --test=e2e-framework -- --packages ./examples/simple
+```
+
+The previous command will launch kubetest2 without starting a cluster (noop deployer). Note the `--` which indicates the start of arguments which will be passed to the tester (e2e-framework).
+
+If the command is successful, you will see the `kubetest2` logs similar to what is shown:
+
+```
+I1211 08:56:43.836568   14380 app.go:61] The files in RunDir shall not be part of Artifacts
+I1211 08:56:43.837144   14380 app.go:62] pass rundir-in-artifacts flag True for RunDir to be part of Artifacts
+I1211 08:56:43.837188   14380 app.go:64] RunDir for this run: "/home/ubuntu/go/e2e-framework/examples/_rundir/cf42e94d-1c2e-4c6f-9912-2ff948608008"
+I1211 08:56:43.860870   14380 app.go:128] ID for this run: "cf42e94d-1c2e-4c6f-9912-2ff948608008"
+Running:  go test  ./simple -args
+ok  	sigs.k8s.io/e2e-framework/examples/simple	0.363s
+```
+
+You can easily change this command to stand up and teardown a Kubernetes cluster using KinD for instance (`kubetest2` also supports other deployers):
+
+```
+$> kubetest2 kind --up --down --test=e2e-framework -- --packages .
+I1211 09:20:46.640997   19579 up.go:62] Up(): creating kind cluster...
+Creating cluster "kind" ...
+ • Ensuring node image (kindest/node:v1.25.3) 🖼  ...
+ ✓ Ensuring node image (kindest/node:v1.25.3) 🖼
+ • Preparing nodes 📦   ...
+...
+Running:  go test   -args
+PASS
+ok  	sigs.k8s.io/e2e-framework/kubetest2test	0.307s
+I1211 09:23:14.406049   19579 down.go:32] Down(): deleting kind cluster...
+Deleting cluster "" ...
+```
+
+> It should be noted that e2e-framework offers its own programmatic hooks for more flexible controls of pre and post test tasks, such as creating and tearing down named clusters (see the examples folder).
+
+### Passing arguments to e2e-framework tests
+The kubetest2 e2e-framework tester supports the ability to pass CLI arguments to control settings such as test execution filters and test behaviors. Recall, in order for your e2e-framework tests to receive CLI arguments, you must programmatically create the test environment to receive its configuration from the command-line:
+
+```go
+
+var tenv env.Environment
+
+func TestMain(m *testing.M) {
+	var err error
+    tenv, err = env.NewFromFlags()
+	if err != nil {
+		log.Fatalf("failed to build env from flags: %s", err)
+	}
+	os.Exit(tenv.Run(m))
+}
+
+func TestClusterObjects(t *testing.T) {
+	f := features.New("cluster-test")
+	f.Assess("pod-count", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+		var pods corev1.PodList
+		client, err := cfg.NewClient()
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = client.Resources("kube-system").List(context.TODO(), &pods)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(pods.Items) == 0 {
+			t.Fatal("no pods in namespace kube-system")
+		}
+		return ctx
+	})
+	f.Assess("dep-count", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+		var deps appsv1.DeploymentList
+		client, err := cfg.NewClient()
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = client.Resources().List(context.TODO(), &deps)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(deps.Items) == 0 {
+			t.Fatal("deployments not found")
+		}
+		return ctx
+	})
+	tenv.Test(t, f.Feature())
+}
+
+```
+
+This test can be launched with kubetest2 to include additional CLI flags that are passed to the e2e-framework tester for configurations, as show:
+
+```
+$> kubetest2 kind --up --down      \
+     --test=e2e-framework --       \
+     --packages ./cluster          \
+     --kubeconfig=$HOME/.kube/config
+```
+The previous command will stand up a kind cluster and pass additional CLI flags `--packages` to indicate the test package and and `--kubeconfig` to point to the configuration file.
+
+The test can be launched to only run the `dep-count` assessment by skipping the others, as shown in the following comomand:
+
+```
+$> kubetest2 kind --up --down        \
+     --test=e2e-framework --         \
+     --packages ./cluster            \
+     --kubeconfig=$HOME/.kube/config \
+     --skip-assessments=pod-count
+```
+
+In case you want to pass additional CLI flags to the Go test binary itself, you can use flag `--test-flags` to do so. For instance, the following runs the test with verbose output:
+
+```
+$> kubetest2 kind --up --down        \
+     --test=e2e-framework --         \
+     --packages ./cluster            \
+     --kubeconfig=$HOME/.kube/config \
+     --skip-assessments=pod-count
+     --test-flags="-v"
+```
+
+The previous `kubetest2` command will run the following `go test` command as shown:
+
+```
+$> go test -v ./cluster -args --kubeconfig=/Users/vivienv/.kube/config --skip-assessment=pod-count
+=== RUN   TestClusterObjects
+=== RUN   TestClusterObjects/cluster-test
+=== RUN   TestClusterObjects/cluster-test/pod-count
+    env.go:441: Skipping assessment: "pod-count": name matched
+=== RUN   TestClusterObjects/cluster-test/dep-count
+--- PASS: TestClusterObjects (0.02s)
+    --- PASS: TestClusterObjects/cluster-test (0.02s)
+        --- SKIP: TestClusterObjects/cluster-test/pod-count (0.00s)
+        --- PASS: TestClusterObjects/cluster-test/dep-count (0.02s)
+PASS
+ok  	sigs.k8s.io/e2e-framework/kubetest2test/cluster	0.374s
+```

--- a/third_party/kubetest2/cmd/kubetest2-tester-e2e-framework/main.go
+++ b/third_party/kubetest2/cmd/kubetest2-tester-e2e-framework/main.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This package implements a kubetest2 tester program that can launch
+// tests written using the e2e-framework (https://github.com/kubernetes-sigs/e2e-framework)
+package main
+
+import (
+	"sigs.k8s.io/e2e-framework/third_party/kubetest2/pkg/tester"
+)
+
+func main() {
+	tester.Main()
+}

--- a/third_party/kubetest2/go.mod
+++ b/third_party/kubetest2/go.mod
@@ -1,0 +1,16 @@
+module sigs.k8s.io/e2e-framework/third_party/kubetest2
+
+go 1.19
+
+require (
+	github.com/octago/sflags v0.2.0
+	k8s.io/klog/v2 v2.70.0
+	sigs.k8s.io/kubetest2 v0.0.0-20221019023504-d306c412d528
+)
+
+require (
+	github.com/go-logr/logr v1.2.0 // indirect
+	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/vladimirvivien/gexe v0.2.0 // indirect
+)

--- a/third_party/kubetest2/go.sum
+++ b/third_party/kubetest2/go.sum
@@ -1,0 +1,14 @@
+github.com/go-logr/logr v1.2.0 h1:QK40JKJyMdUDz+h+xvCsru/bJhvG0UxvePV0ufL/AcE=
+github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
+github.com/octago/sflags v0.2.0 h1:XceYzkRXGAHa/lSFmKLcaxSrsh4MTuOMQdIGsUD0wlk=
+github.com/octago/sflags v0.2.0/go.mod h1:G0bjdxh4qPRycF74a2B8pU36iTp9QHGx0w0dFZXPt80=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/vladimirvivien/gexe v0.2.0 h1:nbdAQ6vbZ+ZNsolCgSVb9Fno60kzSuvtzVh6Ytqi/xY=
+github.com/vladimirvivien/gexe v0.2.0/go.mod h1:LHQL00w/7gDUKIak24n801ABp8C+ni6eBht9vGVst8w=
+k8s.io/klog/v2 v2.70.0 h1:GMmmjoFOrNepPN0ZeGCzvD2Gh5IKRwdFx8W5PBxVTQU=
+k8s.io/klog/v2 v2.70.0/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=
+sigs.k8s.io/kubetest2 v0.0.0-20221019023504-d306c412d528 h1:xuussvbNApLvKPIW0l8BrXSVFfeyGBg/jAoysmsqzhc=
+sigs.k8s.io/kubetest2 v0.0.0-20221019023504-d306c412d528/go.mod h1:4KmbG/H/S8sXiLXH45ddj6NmBUiqde+RxFXrrfIOhMY=

--- a/third_party/kubetest2/pkg/tester/e2e-tester.go
+++ b/third_party/kubetest2/pkg/tester/e2e-tester.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tester
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/octago/sflags/gen/gpflag"
+	"github.com/vladimirvivien/gexe"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/kubetest2/pkg/testers"
+)
+
+var GitTag string
+
+type Tester struct {
+	TestFlags               string `desc:"Space-separated flags applied to 'go test' command"`
+	Namespace               string `desc:"A namespace value to use for testing (optional)"`
+	Kubeconfig              string `desc:"Path to a cluster kubeconfig file (optional)"`
+	Feature                 string `desc:"Regular expression to select feature(s) to test"`
+	Assess                  string `desc:"Regular expression to select assessment(s) to run"`
+	Labels                  string `desc:"Comma-separated key=value to filter features by labels"`
+	SkipLabels              string `desc:"Regular expression to skip label(s) to run"`
+	SkipFeatures            string `desc:"Regular expression to skip feature(s) to run"`
+	SkipAssessment          string `desc:"Regular expression to skip assessment(s) to run"`
+	Parallel                bool   `desc:"Run test features in parallel"`
+	DryRun                  bool   `desc:"Run Test suite in dry-run mode. This will list the tests to be executed without actually running them"`
+	FailFast                bool   `desc:"Fail immediately and stop running untested code"`
+	DisableGracefulTeardown bool   `desc:"Ignore panic recovery while running tests. This will prevent test finish steps from getting executed on panic"`
+	Packages                string `desc:"Space-separated packages to test"`
+}
+
+const usage = `Usage: kubetest2-tester-e2e-framework [e2e-framework-flags]
+When used with kubetest2: kubetest2 [<deployer>] --test=e2e-framework -- [e2e-framework-flags]
+e2e-framework flags:
+`
+
+func (t *Tester) Execute(args []string) error {
+	fs, err := gpflag.Parse(t)
+	if err != nil {
+		return fmt.Errorf("failed to initialize e2e-framework tester: %s", err)
+	}
+
+	fs.AddGoFlagSet(flag.CommandLine)
+
+	help := fs.BoolP("help", "h", false, "")
+	if err := fs.Parse(args); err != nil {
+		return fmt.Errorf("failed to parse flags: %s", err)
+	}
+
+	fs.Usage = func() {
+		fmt.Print(usage)
+	}
+
+	if *help {
+		fs.SetOutput(os.Stdout)
+		fs.Usage()
+		fs.PrintDefaults()
+		return nil
+	}
+
+	if err := testers.WriteVersionToMetadata(GitTag); err != nil {
+		return err
+	}
+	return t.Test()
+}
+
+func (t *Tester) Test() error {
+	testCmd := t.buildCmd()
+	klog.Info("Running: ", testCmd)
+	p := gexe.NewProc(testCmd)
+	p.SetStdout(os.Stdout)
+	p.SetStderr(os.Stderr)
+	return p.Run().Err()
+}
+
+func (t *Tester) buildCmd() string {
+	var testCmd strings.Builder
+	testCmd.WriteString(fmt.Sprintf("go test %s %s -args", t.TestFlags, t.Packages))
+	if t.Namespace != "" {
+		testCmd.WriteString(" --namespace=" + t.Namespace)
+	}
+	if t.Kubeconfig != "" {
+		testCmd.WriteString(" --kubeconfig=" + t.Kubeconfig)
+	}
+	if t.Feature != "" {
+		testCmd.WriteString(" --kubeconfig=" + t.Feature)
+	}
+	if t.SkipFeatures != "" {
+		testCmd.WriteString(" --skip-features=" + t.SkipFeatures)
+	}
+	if t.Assess != "" {
+		testCmd.WriteString(" --assess=" + t.Assess)
+	}
+	if t.SkipAssessment != "" {
+		testCmd.WriteString(" --skip-assessment=" + t.SkipAssessment)
+	}
+	if t.Labels != "" {
+		testCmd.WriteString(" --labels=" + t.Labels)
+	}
+	if t.SkipLabels != "" {
+		testCmd.WriteString(" --skip-labels=" + t.SkipLabels)
+	}
+	if t.Parallel {
+		testCmd.WriteString(" --parallel")
+	}
+	if t.DryRun {
+		testCmd.WriteString(" --dry-run")
+	}
+	if t.FailFast {
+		testCmd.WriteString(" --fail-fast")
+	}
+	if t.DisableGracefulTeardown {
+		testCmd.WriteString(" --disable-graceful-shutdown")
+	}
+
+	return testCmd.String()
+}
+
+func Main() {
+	t := &Tester{}
+	if err := t.Execute(os.Args); err != nil {
+		klog.Fatalf("failed to run e2e-framework tester: %v", err)
+	}
+}

--- a/third_party/kubetest2/pkg/tester/e2e-tester_test.go
+++ b/third_party/kubetest2/pkg/tester/e2e-tester_test.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tester
+
+import (
+	"github.com/octago/sflags/gen/gpflag"
+	"testing"
+)
+
+func TestBuildFlags(t *testing.T) {
+	tests := []struct {
+		name   string
+		args   []string
+		tester *Tester
+	}{
+		{
+			name:   "empty flags",
+			args:   []string{},
+			tester: &Tester{},
+		},
+		{
+			name: "all flags",
+			args: []string{
+				"--packages", ".",
+				"--assess", "volume test",
+				"--feature", "beta",
+				"--labels", "k0=v0, k1=v1, k2=v2",
+				"--skip-labels", "k0=v0, k1=v1",
+				"--skip-features", "networking",
+				"--skip-assessment", "volume test",
+				"--parallel",
+				"--dry-run",
+				"--disable-graceful-teardown",
+			},
+			tester: &Tester{
+				Packages:                ".",
+				Assess:                  "volume test",
+				Feature:                 "beta",
+				Labels:                  "k0=v0, k1=v1, k2=v2",
+				SkipLabels:              "k0=v0, k1=v1",
+				SkipFeatures:            "networking",
+				SkipAssessment:          "volume test",
+				Parallel:                true,
+				DryRun:                  true,
+				DisableGracefulTeardown: true,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			tester := &Tester{}
+			fs, err := gpflag.Parse(tester)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := fs.Parse(test.args); err != nil {
+				t.Fatalf("failed to parse flags: %s", err)
+			}
+			if tester.Packages != test.tester.Packages {
+				t.Errorf("flag 'Package' not matched: expecting %s, got %s", test.tester.Packages, tester.Packages)
+			}
+			if tester.Assess != test.tester.Assess {
+				t.Errorf("flag 'Assess' not matched: expecting %s, got %s", test.tester.Assess, tester.Assess)
+			}
+			if tester.Feature != test.tester.Feature {
+				t.Errorf("flag 'Feature' not matched: expecting %s, got %s", test.tester.Feature, tester.Feature)
+			}
+			if tester.Labels != test.tester.Labels {
+				t.Errorf("flag 'Labels' not matched: expecting %s, got %s", test.tester.Labels, tester.Labels)
+			}
+			if tester.SkipLabels != test.tester.SkipLabels {
+				t.Errorf("flag 'SkipLabels' not matched: expecting %s, got %s", test.tester.SkipLabels, tester.SkipLabels)
+			}
+			if tester.SkipFeatures != test.tester.SkipFeatures {
+				t.Errorf("flag 'SkipFeatures' not matched: expecting %s, got %s", test.tester.SkipFeatures, tester.SkipFeatures)
+			}
+			if tester.SkipAssessment != test.tester.SkipAssessment {
+				t.Errorf("flag 'SkipAssessment' not matched: expecting %s, got %s", test.tester.SkipAssessment, tester.SkipAssessment)
+			}
+			if tester.Parallel != test.tester.Parallel {
+				t.Errorf("flag 'Parallel' not matched: expecting %t, got %t", test.tester.Parallel, tester.Parallel)
+			}
+			if tester.DryRun != test.tester.DryRun {
+				t.Errorf("flag 'DryRun' not matched: expecting %t, got %t", test.tester.DryRun, tester.DryRun)
+			}
+			if tester.DisableGracefulTeardown != test.tester.DisableGracefulTeardown {
+				t.Errorf("flag 'DisableGracefulTeardown' not matched: expecting %t, got %t", test.tester.DisableGracefulTeardown, tester.DisableGracefulTeardown)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR implements a kubetest2 tester to run e2e-framework tests can be executed with kubetest2 as:

```bash
$> kubetest2 kind --up --down        \
     --test=e2e-framework --         \
     --packages ./cluster            \
     --kubeconfig=$HOME/.kube/config \
     --skip-assessments=pod-count
```

See README.md for doc.

Closes #132 
Closes #174