### PR TITLE
fix: Parse multiple label values for same key

### DIFF
--- a/pkg/env/env_test.go
+++ b/pkg/env/env_test.go
@@ -450,12 +450,12 @@ func TestEnv_Test(t *testing.T) {
 
 					// Ensure changes aren't persisted to the afterEachFeature hook
 					labelMap := info.Labels()
-					labelMap["foo"] = "bar"
+					labelMap["foo"] = []string{"bar"}
 					return ctx, nil
 				}).AfterEachFeature(func(ctx context.Context, _ *envconf.Config, _ *testing.T, info features.Feature) (context.Context, error) {
 					val = append(val, "after-each-feature")
 					t.Logf("%#v, len(steps)=%v\n", info, len(info.Steps()))
-					if info.Labels()["foo"] == "bar" {
+					if info.Labels().Contains("foo", "bar") {
 						t.Errorf("Expected label from previous feature hook to not include foo:bar")
 					}
 					if len(info.Steps()) == 0 {

--- a/pkg/envconf/config.go
+++ b/pkg/envconf/config.go
@@ -36,9 +36,9 @@ type Config struct {
 	namespace               string
 	assessmentRegex         *regexp.Regexp
 	featureRegex            *regexp.Regexp
-	labels                  map[string]string
+	labels                  flags.LabelsMap
 	skipFeatureRegex        *regexp.Regexp
-	skipLabels              map[string]string
+	skipLabels              flags.LabelsMap
 	skipAssessmentRegex     *regexp.Regexp
 	parallelTests           bool
 	dryRun                  bool
@@ -203,24 +203,24 @@ func (c *Config) SkipFeatureRegex() *regexp.Regexp {
 }
 
 // WithLabels sets the environment label filters
-func (c *Config) WithLabels(lbls map[string]string) *Config {
+func (c *Config) WithLabels(lbls map[string][]string) *Config {
 	c.labels = lbls
 	return c
 }
 
 // Labels returns the environment's label filters
-func (c *Config) Labels() map[string]string {
+func (c *Config) Labels() map[string][]string {
 	return c.labels
 }
 
 // WithSkipLabels sets the environment label filters
-func (c *Config) WithSkipLabels(lbls map[string]string) *Config {
+func (c *Config) WithSkipLabels(lbls map[string][]string) *Config {
 	c.skipLabels = lbls
 	return c
 }
 
 // SkipLabels returns the environment's label filters
-func (c *Config) SkipLabels() map[string]string {
+func (c *Config) SkipLabels() map[string][]string {
 	return c.skipLabels
 }
 

--- a/pkg/features/builder.go
+++ b/pkg/features/builder.go
@@ -34,7 +34,7 @@ func New(name string) *FeatureBuilder {
 
 // WithLabel adds a test label key/value pair
 func (b *FeatureBuilder) WithLabel(key, value string) *FeatureBuilder {
-	b.feat.labels[key] = value
+	b.feat.labels[key] = append(b.feat.labels[key], value)
 	return b
 }
 

--- a/pkg/features/builder_test.go
+++ b/pkg/features/builder_test.go
@@ -58,12 +58,22 @@ func TestFeatureBuilder(t *testing.T) {
 		{
 			name: "with labels",
 			setup: func(t *testing.T) types.Feature {
-				return New("test").WithLabel("a", "b").WithLabel("c", "d").Feature()
+				return New("test").
+					WithLabel("a", "a").
+					WithLabel("a", "aa").
+					WithLabel("b", "b").
+					Feature()
 			},
 			eval: func(t *testing.T, f types.Feature) {
 				ft := f.(*defaultFeature) // nolint
 				if len(ft.labels) != 2 {
 					t.Error("unexpected labels len:", len(ft.labels))
+				}
+				if len(ft.labels["a"]) != 2 {
+					t.Errorf("unexpected label values for %q: %q", "a", ft.labels["a"])
+				}
+				if len(ft.labels["b"]) != 1 {
+					t.Errorf("unexpected label values for %q: %q", "b", ft.labels["b"])
 				}
 			},
 		},
@@ -116,7 +126,7 @@ func TestFeatureBuilder(t *testing.T) {
 				}).Feature()
 			},
 			eval: func(t *testing.T, f types.Feature) {
-				ft := f.(*defaultFeature) //nolint
+				ft := f.(*defaultFeature) // nolint
 				setups := GetStepsByLevel(ft.Steps(), types.LevelSetup)
 				if setups[0].Name() != "setup-test" {
 					t.Errorf("unexpected setup name: %s", setups[0].Name())
@@ -172,7 +182,7 @@ func TestFeatureBuilder(t *testing.T) {
 				}).Feature()
 			},
 			eval: func(t *testing.T, f types.Feature) {
-				ft := f.(*defaultFeature) //nolint
+				ft := f.(*defaultFeature) // nolint
 				setups := GetStepsByLevel(ft.Steps(), types.LevelTeardown)
 				if setups[0].Name() != "teardown-test" {
 					t.Errorf("unexpected teardown name: %s", setups[0].Name())

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -280,10 +280,10 @@ func ParseArgs(args []string) (*EnvFlags, error) {
 	}, nil
 }
 
-type LabelsMap map[string]string
+type LabelsMap map[string][]string
 
 func (m LabelsMap) String() string {
-	i := map[string]string(m)
+	i := map[string][]string(m)
 	return fmt.Sprint(i)
 }
 
@@ -295,8 +295,19 @@ func (m LabelsMap) Set(val string) error {
 		if len(kv) != 2 {
 			return fmt.Errorf("label format error: %s", label)
 		}
-		m[strings.TrimSpace(kv[0])] = strings.TrimSpace(kv[1])
+		k := strings.TrimSpace(kv[0])
+		v := strings.TrimSpace(kv[1])
+		m[k] = append(m[k], v)
 	}
 
 	return nil
+}
+
+func (m LabelsMap) Contains(key, val string) bool {
+	for _, v := range m[key] {
+		if val == v {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/internal/types/types.go
+++ b/pkg/internal/types/types.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/flags"
 )
 
 // EnvFunc represents a user-defined operation that
@@ -86,7 +87,7 @@ type Environment interface {
 	Run(*testing.M) int
 }
 
-type Labels map[string]string
+type Labels = flags.LabelsMap
 
 type Feature interface {
 	// Name is a descriptive text for the feature


### PR DESCRIPTION
Changes `--labels` and `--skip-labels` parsing logic to allow for multiple values for the same label `key`.

Fixes: #194 