### PR TITLE
Add --context flag

### DIFF
--- a/examples/flags/README.md
+++ b/examples/flags/README.md
@@ -68,3 +68,9 @@ To get additional verbose logs
 ```shell
 ./flags.test --assess es --v 2
 ```
+
+To run a test against a particular Kubeconfig context
+
+```shell
+./flags.test --kubeconfig ~/path/to/kubeconfig --context my-context
+```

--- a/klient/conf/config.go
+++ b/klient/conf/config.go
@@ -18,6 +18,7 @@ limitations under the License.
 package conf
 
 import (
+	"errors"
 	"flag"
 	"os"
 	"os/user"
@@ -33,14 +34,32 @@ var DefaultClusterContext = ""
 // New returns Kubernetes configuration value of type *rest.Config.
 // filename is kubeconfig file
 func New(fileName string) (*rest.Config, error) {
-	// if filename is not provided assume in-cluster-config
+	var resolvedKubeConfigFile string
+	kubeContext := ResolveClusterContext()
+
+	// resolve the kubeconfig file
+	resolvedKubeConfigFile = fileName
 	if fileName == "" {
-		return rest.InClusterConfig()
+		resolvedKubeConfigFile = ResolveKubeConfigFile()
 	}
 
-	// create the config object from k8s config path
+	// if resolvedKubeConfigFile is still empty, assume in-cluster config
+	if resolvedKubeConfigFile == "" {
+		if kubeContext == "" {
+			return rest.InClusterConfig()
+		}
+		// if in-cluster can't use the --kubeContext flag
+		return nil, errors.New("cannot use a cluster context without a valid kubeconfig file")
+	}
+
+	// set the desired context if provided
+	if kubeContext != "" {
+		return NewWithContextName(resolvedKubeConfigFile, kubeContext)
+	}
+
+	// create the config object from resolvedKubeConfigFile without a context
 	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-		&clientcmd.ClientConfigLoadingRules{ExplicitPath: fileName}, &clientcmd.ConfigOverrides{}).ClientConfig()
+		&clientcmd.ClientConfigLoadingRules{ExplicitPath: resolvedKubeConfigFile}, &clientcmd.ConfigOverrides{}).ClientConfig()
 }
 
 // NewWithContextName returns k8s config value of type *rest.Config
@@ -110,9 +129,9 @@ func ResolveKubeConfigFile() string {
 
 // ResolveClusterContext returns cluster context name based on --context flag.
 func ResolveClusterContext() string {
-	// If a flag --kube-context is specified use that
+	// If a flag --context is specified use that
 	if flag.Parsed() {
-		f := flag.Lookup("kube-context")
+		f := flag.Lookup("context")
 		if f != nil {
 			return f.Value.String()
 		}

--- a/klient/conf/main_test.go
+++ b/klient/conf/main_test.go
@@ -40,6 +40,7 @@ func setup() {
 
 	kubeconfigdir := filepath.Join(home, "test", ".kube")
 	kubeconfigpath := filepath.Join(kubeconfigdir, "config")
+	kubeContext := "test-context"
 
 	// check if file exists
 	_, err := os.Stat(kubeconfigpath)
@@ -52,7 +53,7 @@ func setup() {
 		}
 
 		// generate kube config data
-		data := genKubeconfig("test-context")
+		data := genKubeconfig(kubeContext)
 
 		err = createFile(kubeconfigpath, data)
 		if err != nil {
@@ -64,11 +65,19 @@ func setup() {
 	log.Info("file created successfully", kubeconfigpath)
 
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "Paths to a kubeconfig. Only required if out-of-cluster.")
+	flag.StringVar(&kubeContext, "context", "", "The name of the kubeconfig context to use. Only required if out-of-cluster.")
 
 	// set --kubeconfig flag
 	err = flag.Set("kubeconfig", kubeconfigpath)
 	if err != nil {
-		log.ErrorS(err, "unexpected error while setting flag value")
+		log.ErrorS(err, "unexpected error while setting kubeconfig flag value")
+		return
+	}
+
+	// set --context flag
+	err = flag.Set("context", kubeContext)
+	if err != nil {
+		log.ErrorS(err, "unexpected error while setting context flag value")
 		return
 	}
 

--- a/pkg/envconf/config.go
+++ b/pkg/envconf/config.go
@@ -44,6 +44,7 @@ type Config struct {
 	dryRun                  bool
 	failFast                bool
 	disableGracefulTeardown bool
+	kubeContext             string
 }
 
 // New creates and initializes an empty environment configuration
@@ -85,6 +86,7 @@ func NewFromFlags() (*Config, error) {
 	e.dryRun = envFlags.DryRun()
 	e.failFast = envFlags.FailFast()
 	e.disableGracefulTeardown = envFlags.DisableGracefulTeardown()
+	e.kubeContext = envFlags.KubeContext()
 
 	return e, nil
 }
@@ -272,6 +274,17 @@ func (c *Config) WithDisableGracefulTeardown() *Config {
 // DisableGracefulTeardown is used to check the panic recovery handler should be enabled
 func (c *Config) DisableGracefulTeardown() bool {
 	return c.disableGracefulTeardown
+}
+
+// WithKubeContext is used to set the kubeconfig context
+func (c *Config) WithKubeContext(kubeContext string) *Config {
+	c.kubeContext = kubeContext
+	return c
+}
+
+// WithKubeContext is used to get the kubeconfig context
+func (c *Config) KubeContext() string {
+	return c.kubeContext
 }
 
 func randNS() string {

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -38,6 +38,7 @@ const (
 	flagDryRunName              = "dry-run"
 	flagFailFast                = "fail-fast"
 	flagDisableGracefulTeardown = "disable-graceful-teardown"
+	flagContext                 = "context"
 )
 
 // Supported flag definitions
@@ -90,6 +91,10 @@ var (
 		Name:  flagDisableGracefulTeardown,
 		Usage: "Ignore panic recovery while running tests. This will prevent test finish steps from getting executed on panic",
 	}
+	contextFlag = flag.Flag{
+		Name:  flagContext,
+		Usage: "The name of the kubeconfig context to use",
+	}
 )
 
 // EnvFlags surfaces all resolved flag values for the testing framework
@@ -106,6 +111,7 @@ type EnvFlags struct {
 	dryRun                  bool
 	failFast                bool
 	disableGracefulTeardown bool
+	kubeContext             string
 }
 
 // Feature returns value for `-feature` flag
@@ -180,6 +186,11 @@ func Parse() (*EnvFlags, error) {
 	return ParseArgs(os.Args[1:])
 }
 
+// Context returns an optional kubeconfig context to use
+func (f *EnvFlags) KubeContext() string {
+	return f.kubeContext
+}
+
 // ParseArgs parses the specified args from global flag.CommandLine
 // and returns a set of environment flag values.
 func ParseArgs(args []string) (*EnvFlags, error) {
@@ -194,6 +205,7 @@ func ParseArgs(args []string) (*EnvFlags, error) {
 		dryRun                  bool
 		failFast                bool
 		disableGracefulTeardown bool
+		kubeContext             string
 	)
 
 	labels := make(LabelsMap)
@@ -247,6 +259,10 @@ func ParseArgs(args []string) (*EnvFlags, error) {
 		flag.BoolVar(&disableGracefulTeardown, disableGracefulTeardownFlag.Name, false, disableGracefulTeardownFlag.Usage)
 	}
 
+	if flag.Lookup(contextFlag.Name) == nil {
+		flag.StringVar(&kubeContext, contextFlag.Name, contextFlag.DefValue, contextFlag.Usage)
+	}
+
 	// Enable klog/v2 flag integration
 	klog.InitFlags(nil)
 
@@ -277,6 +293,7 @@ func ParseArgs(args []string) (*EnvFlags, error) {
 		dryRun:                  dryRun,
 		failFast:                failFast,
 		disableGracefulTeardown: disableGracefulTeardown,
+		kubeContext:             kubeContext,
 	}, nil
 }
 


### PR DESCRIPTION
Fix https://github.com/kubernetes-sigs/e2e-framework/issues/187

@vladimirvivien I know this is not what you suggested, but I spent some time looking at the cli-runtime and couldn't figure out how to wire it.
Since this is blocking our adoption and it is a pretty simple change, I'd like to ask you if we can still merge it and then I can try to take again a look at the cli-runtime fix