### PR TITLE
Document -skip flag in go test

### DIFF
--- a/examples/skip_flags/README.md
+++ b/examples/skip_flags/README.md
@@ -75,13 +75,13 @@ To skip a test by test function name `TestSkipFlags`, do the following
 go test -v . --skip TestSkipFlags
 ```
 
-To skip a feature with name `pod list` within test function `TestSkipFlags`
+To skip a feature with name `pod list` within test function `TestSkipFlags`, do the following
 
 ```shell
 go test -v . --skip TestSkipFlags/pod list
 ```
 
-To skip a assesment with name `pods from kube-system` within feature `pod list` within test function `TestSkipFlags`
+To skip a assesment with name `pods from kube-system` within feature `pod list` within test function `TestSkipFlags`,  do the following
 ```shell
 go test -v . --skip TestSkipFlags/pod list/pods from kube-system
 ```

--- a/examples/skip_flags/README.md
+++ b/examples/skip_flags/README.md
@@ -88,6 +88,24 @@ To skip a assesment with name `pods from kube-system` within feature `pod list` 
 
 ```shell
 go test -v . -skip TestSkipFlags/pod list/pods from kube-system
-```
+``` 
 
 It is not possible to skip features by label name with this option
+
+
+### Skip tests using both -skip flag and --skip-xxx flags
+
+We can also use the combination of `-skip` flag built in `go test` and `-skip-xxx` flags provided by the e2e-framework to skip multiple tests
+
+
+To skip a feature `pod list` within test function `TestSkipFlags` and feature `appsv1/deployment` within test function `TestSkipFlags`, do the following
+
+```shell
+go test -v . -skip TestSkipFlags/appsv1/deployment -args --skip-features "pod list"
+```
+
+To skip a particular labeled feature with label `env=prod` and assesment `deployment creation` within feature `appsv1/deployment` within test function `TestSkipFlags`, do the following
+
+```shell
+go test -v . -skip TestSkipFlags/appsv1/deployment/deployment_creation -args --skip-labels "env=prod"
+```

--- a/examples/skip_flags/README.md
+++ b/examples/skip_flags/README.md
@@ -64,7 +64,8 @@ To skip a particular labeled feature , do the following
 Go 1.20 introduces the ```-skip``` flag for ```go test``` command to skip tests. 
 
 
-This flag allows us to skip tests by test function name, feature name and assesment name
+Tests can also be skipped based on test function name, feature name and assesment name with ```-skip``` flag
+
 ```shell
 go test -v . --skip <test_function_name>/<feature_name>/<assesment_name>
 ```

--- a/examples/skip_flags/README.md
+++ b/examples/skip_flags/README.md
@@ -58,3 +58,30 @@ To skip a particular labeled feature , do the following
 ```shell
 ./skipflags.test --skip-labels "env=prod"
 ```
+
+### Skip tests using built in --skip flag in go test 
+
+Go 1.20 introduces the ```-skip``` flag for ```go test``` command to skip tests. 
+
+
+This flag allows us to skip tests by test function name, feature name and assesment name
+```shell
+go test -v . --skip <test_function_name>/<feature_name>/<assesment_name>
+```
+
+To skip a test by test function name `TestSkipFlags`, do the following
+```shell
+go test -v . --skip TestSkipFlags
+```
+
+To skip a feature with name `pod list` within test function `TestSkipFlags`
+
+```shell
+go test -v . --skip TestSkipFlags/pod list
+```
+
+To skip a assesment with name `pods from kube-system` within feature `pod list` within test function `TestSkipFlags`
+```shell
+go test -v . --skip TestSkipFlags/pod list/pods from kube-system
+```
+It is not possible to skip features by label name with this option

--- a/examples/skip_flags/README.md
+++ b/examples/skip_flags/README.md
@@ -59,30 +59,35 @@ To skip a particular labeled feature , do the following
 ./skipflags.test --skip-labels "env=prod"
 ```
 
-### Skip tests using built in --skip flag in go test 
+### Skip tests using built in -skip flag in go test 
 
-Go 1.20 introduces the ```-skip``` flag for ```go test``` command to skip tests. 
+Go 1.20 introduces the `-skip` flag for `go test` command to skip tests. 
 
 
-Tests can also be skipped based on test function name, feature name and assesment name with ```-skip``` flag
+Tests can also be skipped based on test function name, feature name and assesment name with `-skip` flag
 
 ```shell
-go test -v . --skip <test_function_name>/<feature_name>/<assesment_name>
+go test -v . -skip <test_function_name>/<feature_name>/<assesment_name>
 ```
 
 To skip a test by test function name `TestSkipFlags`, do the following
+
 ```shell
-go test -v . --skip TestSkipFlags
+go test -v . -skip TestSkipFlags
 ```
+
 
 To skip a feature with name `pod list` within test function `TestSkipFlags`, do the following
 
 ```shell
-go test -v . --skip TestSkipFlags/pod list
+go test -v . -skip TestSkipFlags/pod list
 ```
 
+
 To skip a assesment with name `pods from kube-system` within feature `pod list` within test function `TestSkipFlags`,  do the following
+
 ```shell
-go test -v . --skip TestSkipFlags/pod list/pods from kube-system
+go test -v . -skip TestSkipFlags/pod list/pods from kube-system
 ```
+
 It is not possible to skip features by label name with this option


### PR DESCRIPTION
Fixes https://github.com/kubernetes-sigs/e2e-framework/issues/200

Go 1.20 introduces the ```-skip``` flag for ```go test``` command to skip tests.
Document how to use this flag in examples/skip_flags
