### PR TITLE
Select flag and labels logic change

### DIFF
--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -524,7 +524,8 @@ func (e *testEnv) requireProcessing(kind, testName string, requiredRegexp, skipR
 			}
 		}
 
-		skip = true
+		// if there are no labels passed through --labels then we can directly set skip to false and continue, the loop wont run anyway
+		skip = len(e.cfg.Labels()) != 0
 	checkLabels:
 		for key, vals := range e.cfg.Labels() {
 			for _, v := range vals {

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -513,6 +513,17 @@ func (e *testEnv) requireProcessing(kind, testName string, requiredRegexp, skipR
 	}
 
 	if labels != nil {
+
+		for key, vals := range e.cfg.SelectLabels() {
+			for _, v := range vals {
+				if !labels.Contains(key, v) {
+					skip = true
+					message = fmt.Sprintf(`Skipping feature "%s": unmatched label "%s=%s"`, testName, key, v)
+					return skip, message
+				}
+			}
+		}
+
 		skip = true
 	checkLabels:
 		for key, vals := range e.cfg.Labels() {
@@ -527,16 +538,6 @@ func (e *testEnv) requireProcessing(kind, testName string, requiredRegexp, skipR
 		if skip {
 			message = fmt.Sprintf(`Skipping feature "%s": no matched labels`, testName)
 			return skip, message
-		}
-
-		for key, vals := range e.cfg.SelectLabels() {
-			for _, v := range vals {
-				if !labels.Contains(key, v) {
-					skip = true
-					message = fmt.Sprintf(`Skipping feature "%s": unmatched label "%s=%s"`, testName, key, v)
-					return skip, message
-				}
-			}
 		}
 
 		// skip running a feature if labels matches with --skip-labels

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -513,7 +513,23 @@ func (e *testEnv) requireProcessing(kind, testName string, requiredRegexp, skipR
 	}
 
 	if labels != nil {
+		skip = true
+	checkLabels:
 		for key, vals := range e.cfg.Labels() {
+			for _, v := range vals {
+				if labels.Contains(key, v) {
+					skip = false
+					break checkLabels
+				}
+			}
+		}
+
+		if skip {
+			message = fmt.Sprintf(`Skipping feature "%s": no matched labels`, testName)
+			return skip, message
+		}
+
+		for key, vals := range e.cfg.SelectLabels() {
 			for _, v := range vals {
 				if !labels.Contains(key, v) {
 					skip = true

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -513,7 +513,6 @@ func (e *testEnv) requireProcessing(kind, testName string, requiredRegexp, skipR
 	}
 
 	if labels != nil {
-
 		for key, vals := range e.cfg.SelectLabels() {
 			for _, v := range vals {
 				if !labels.Contains(key, v) {

--- a/pkg/envconf/config.go
+++ b/pkg/envconf/config.go
@@ -37,6 +37,7 @@ type Config struct {
 	assessmentRegex         *regexp.Regexp
 	featureRegex            *regexp.Regexp
 	labels                  flags.LabelsMap
+	selectLabels            flags.LabelsMap
 	skipFeatureRegex        *regexp.Regexp
 	skipLabels              flags.LabelsMap
 	skipAssessmentRegex     *regexp.Regexp
@@ -73,6 +74,7 @@ func NewFromFlags() (*Config, error) {
 		e.featureRegex = regexp.MustCompile(envFlags.Feature())
 	}
 	e.labels = envFlags.Labels()
+	e.selectLabels = envFlags.SelectLabels()
 	e.namespace = envFlags.Namespace()
 	e.kubeconfig = envFlags.Kubeconfig()
 	if envFlags.SkipFeatures() != "" {
@@ -213,6 +215,17 @@ func (c *Config) WithLabels(lbls map[string][]string) *Config {
 // Labels returns the environment's label filters
 func (c *Config) Labels() map[string][]string {
 	return c.labels
+}
+
+// SelectLabels returns the environment's selectLabels filters
+func (c *Config) SelectLabels() map[string][]string {
+	return c.selectLabels
+}
+
+// WithSelectLabels sets the environment select labels filters
+func (c *Config) WithSelectLabels(lbls map[string][]string) *Config {
+	c.selectLabels = lbls
+	return c
 }
 
 // WithSkipLabels sets the environment label filters

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -31,6 +31,7 @@ const (
 	flagFeatureName             = "feature"
 	flagAssessName              = "assess"
 	flagLabelsName              = "labels"
+	flagSelectLabelsName        = "select-labels"
 	flagSkipLabelName           = "skip-labels"
 	flagSkipFeatureName         = "skip-features"
 	flagSkipAssessmentName      = "skip-assessment"
@@ -53,8 +54,11 @@ var (
 	}
 	labelsFlag = flag.Flag{
 		Name:  flagLabelsName,
-		Usage: "Comma-separated key=value to filter features by labels",
+		Usage: "Comma-separated key=value to filter features by labels, checks for presence of any of the given labels",
 	}
+	selectLabelsFlag = flag.Flag{
+		Name:  flagSelectLabelsName,
+		Usage: "Comma-separated key=value to select features by labels, checks for presence of all the given labels"}
 	kubecfgFlag = flag.Flag{
 		Name:  flagKubecofigName,
 		Usage: "Path to a cluster kubeconfig file (optional)",
@@ -102,6 +106,7 @@ type EnvFlags struct {
 	feature                 string
 	assess                  string
 	labels                  LabelsMap
+	selectLabels            LabelsMap
 	kubeconfig              string
 	namespace               string
 	skiplabels              LabelsMap
@@ -127,6 +132,11 @@ func (f *EnvFlags) Assessment() string {
 // Labels returns a map of parsed key/value from `-labels` flag
 func (f *EnvFlags) Labels() LabelsMap {
 	return f.labels
+}
+
+// Labels returns a map of parsed key/value from `-select-labels` flag
+func (f *EnvFlags) SelectLabels() LabelsMap {
+	return f.selectLabels
 }
 
 // Namespace returns an optional namespace flag value
@@ -209,6 +219,7 @@ func ParseArgs(args []string) (*EnvFlags, error) {
 	)
 
 	labels := make(LabelsMap)
+	selectLabels := make(LabelsMap)
 	skipLabels := make(LabelsMap)
 
 	if flag.Lookup(featureFlag.Name) == nil {
@@ -229,6 +240,10 @@ func ParseArgs(args []string) (*EnvFlags, error) {
 
 	if flag.Lookup(labelsFlag.Name) == nil {
 		flag.Var(&labels, labelsFlag.Name, labelsFlag.Usage)
+	}
+
+	if flag.Lookup(selectLabelsFlag.Name) == nil {
+		flag.Var(&selectLabels, selectLabelsFlag.Name, selectLabelsFlag.Usage)
 	}
 
 	if flag.Lookup(skipLabelsFlag.Name) == nil {
@@ -284,6 +299,7 @@ func ParseArgs(args []string) (*EnvFlags, error) {
 		feature:                 feature,
 		assess:                  assess,
 		labels:                  labels,
+		selectLabels:            selectLabels,
 		namespace:               namespace,
 		kubeconfig:              kubeconfig,
 		skiplabels:              skipLabels,

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -58,7 +58,8 @@ var (
 	}
 	selectLabelsFlag = flag.Flag{
 		Name:  flagSelectLabelsName,
-		Usage: "Comma-separated key=value to select features by labels, checks for presence of all the given labels"}
+		Usage: "Comma-separated key=value to select features by labels, checks for presence of all the given labels",
+	}
 	kubecfgFlag = flag.Flag{
 		Name:  flagKubecofigName,
 		Usage: "Path to a cluster kubeconfig file (optional)",


### PR DESCRIPTION
Resolves #218 .

The naming could be changed a bit but the idea is the same. I've tested the changes on a sample test locally.

Will update the test files soon.


This PR adds a new flag `--select-labels` which will AND the labels ( similar to the previous behaviour of `--labels` ) and change the `--labels` flag behaviour to OR the labels.