### PR TITLE
pin helm chart to a specific version

### DIFF
--- a/examples/third_party_integration/helm/helm_test.go
+++ b/examples/third_party_integration/helm/helm_test.go
@@ -47,7 +47,11 @@ func TestHelmChartRepoWorkflow(t *testing.T) {
 			if err != nil {
 				t.Fatal("failed to upgrade helm repo")
 			}
-			err = manager.RunInstall(helm.WithName("nginx"), helm.WithNamespace(namespace), helm.WithReleaseName("nginx-stable/nginx-ingress"))
+			err = manager.RunInstall(helm.WithName("nginx"), helm.WithNamespace(namespace),
+				helm.WithReleaseName("nginx-stable/nginx-ingress"),
+				// pinning to a specific verision to make sure we will have reproducible executions
+				helm.WithVersion("0.17.0"),
+			)
 			if err != nil {
 				t.Fatal("failed to install nginx Helm chart")
 			}


### PR DESCRIPTION
Follow up of https://github.com/kubernetes-sigs/e2e-framework/pull/229/files#r1155138390

but instead, publish our own lets pin to a specific version that is working
will be too much work and does worth publishing a test one for testing IMHO

/assign @vladimirvivien @harshanarayana 