### PR TITLE
Fixes references in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ include:
 * Rely on built-in Go test features to easily select/filter tests to run during execution
 * And more
 
-For more detail, see the [design document](./docs/design/test-harness-framework.md).
+For more detail, see the [design document](./docs/design).
 
 ## Getting started
 

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -51,7 +51,7 @@ The following shows a proposed type for the environment:
 
 ```go
 // EnvFunc is an operation applied during/after environment setup
-type EnvFunc func(context.Context, envconf.Config) (context.Context, error)
+type EnvFunc func(context.Context, *envconf.Config) (context.Context, error)
 
 type Environment interface {
     // Config returns the associated environment configuration
@@ -93,11 +93,11 @@ env.New() Environment
 
 // env.NewWithConfig creates env.Environment with a specified 
 // environment config and a default context.Context
-env.NewWithConfig(envconf.Config) Environment
+env.NewWithConfig(*envconf.Config) Environment
 
 // env.NewWithContext creates an environment with a specified
 // environment Config and context.Context
-env.NewWithContext(context.Context, envconf.Config) (Environment, error)
+env.NewWithContext(context.Context, *envconf.Config) (Environment, error)
 ```
 
 ### `env.Environment` and context.Context
@@ -130,14 +130,14 @@ ctx := env.New().Context()
 Test writers can specify an environment operation using type `EnvFunc`.
 
 ```go
-type EnvFunc func(context.Context, envconf.Config) (context.Context, error)
+type EnvFunc func(context.Context, *envconf.Config) (context.Context, error)
 ```
 
 An environment operation can be applied at different stages during the life cycle of the environment including environment setup, before a test, after a test, and to tear down the environment. At runtime, the environment operation will receive the environment context that was injected at construction time (or the default context). The context's content (key/value) can be mutated during the operation and returned.
 
 ```go 
 e := env.New()
-e.Setup(func(ctx context.Context, client conf envconf.Config){
+e.Setup(func(ctx context.Context, client conf *envconf.Config){
   // define environment operation here
 })
 ```
@@ -200,7 +200,7 @@ The operation performed during an execution step is defined as the following Go 
 type StepFunc func (context.Context, *testing.T, envconf.Config) context.Context
 ```
 
-When a step is executed, it will receive the last updated `context.Context`, `*testing.T` for test signaling, and the `envconf.Config` that is associated with the environment. Note a step function can update the content of the context and return it so that its value will be passed to subsequent steps.
+When a step is executed, it will receive the last updated `context.Context`, `*testing.T` for test signaling, and the `*envconf.Config` that is associated with the environment. Note a step function can update the content of the context and return it so that its value will be passed to subsequent steps.
 
 #### Step levels
 A step level identifies the type of a step.  It shall be encoded as the following type, shown below.
@@ -279,7 +279,7 @@ var (
 
 func TestMain(m *testing.M) {
     global = env.New()    
-    global.Setup(func(context.Context, *cfg envconf.Config) (context.Context, error){
+    global.Setup(func(context.Context, cfg *envconf.Config) (context.Context, error){
         // code to setup environment
         return nil, nil
     })

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -256,7 +256,7 @@ var (
 
 func TestMain(m *testing.M) {
     global = env.New()    
-    global.Setup(func(context.Context, cfg envconf.Config) (context.Context, error){
+    global.Setup(func(context.Context, cfg *envconf.Config) (context.Context, error){
         // code to setup environment
         return nil, nil
     })
@@ -279,7 +279,7 @@ var (
 
 func TestMain(m *testing.M) {
     global = env.New()    
-    global.Setup(func(context.Context, cfg envconf.Config) (context.Context, error){
+    global.Setup(func(context.Context, *cfg envconf.Config) (context.Context, error){
         // code to setup environment
         return nil, nil
     })
@@ -305,7 +305,7 @@ Before a feature can be tested, it must be defined.  Assuming that the framework
 ```go
 func TestSomething(t *testing.T) {       
     feat := features.New("Hello Feature").
-        Assess("Simple test", func(ctx context.Context, t *testing.T, cfg envconf.Config) context.Context {
+        Assess("Simple test", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
             result := "foo"
             if result != "Hello foo" {
                 t.Error("unexpected message")
@@ -324,7 +324,7 @@ Next the feature can be tested.  This is done by invoking the `Test` method on t
 ```go
 func TestSomething(t *testing.T) {
     feat := features.New("Hello Feature").
-        Assess("Simple test", func(ctx context.Context, t *testing.T, cfg envconf.Config) context.Context {
+        Assess("Simple test", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
             result := "foo"
             if result != "Hello foo" {
                 t.Error("unexpected message")
@@ -344,12 +344,12 @@ After all tests in the package (or suite) are executed, the test framework will 
 ```go
 func TestMain(m *testing.M) {
     ...
-    env.Setup(func(ctx context.Context, cfg envconf.Config) (context.Context, error){
+    env.Setup(func(ctx context.Context, cfg *envconf.Config) (context.Context, error){
         // setup environment
         return ctx, nil
     })
 
-    env.Finish(func(ctx context.Context, cfg envconf.Config) (context.Context, error){
+    env.Finish(func(ctx context.Context, cfg *envconf.Config) (context.Context, error){
         // teardown environment
         return ctx, nil
     })


### PR DESCRIPTION
This PR addresses some issues I noticed with the documentation while going through it. These issues are:

1. A broken link in the design document reference in `readme.md`.
2. Fixes multiple references to `envconf.Config` that refer to its usage as an object instead of as a pointer.