### PR TITLE
fix: Label handling

### DIFF
--- a/examples/skip_flags/README.md
+++ b/examples/skip_flags/README.md
@@ -1,11 +1,14 @@
 
 # CLI flags
 
-The test harness framework supports several CLI flags that can be used to influence how tests are executed. This example shows how to create tests that are configured using the CLI flags.
+The test harness framework supports several CLI flags that can be used to influence how tests are executed. This example
+shows how to run or skip specific tests (features) using `--skip-features`, `--labels`, and `--skip-labels`. See
+[examples/flags](../flags/README.md) for a full list of supported flags.
 
 ## Configure tests with CLI flags
 
-To drive your tests with CLI flags, you must initialize a test environment using the passed in CLI flags. This is done by calling `envconf.NewFromFlags` function to create configuration for the environment as shown below:
+To drive your tests with CLI flags, you must initialize a test environment using the passed in CLI flags. This is done
+by calling `envconf.NewFromFlags` function to create configuration for the environment as shown below:
 
 ```go
 var test env.Environment
@@ -20,22 +23,17 @@ func TestMain(m *testing.M) {
 }
 ```
 
-### Supported flags
+### Use `Labels` in your tests
 
-There are several supported flags (for more accurate list, see package `pkg/flag`):
-
-* `assess`
-* `features`
-* `labels`
-* `kubeconfig`
-* `namespace`
-* `skip-assessment`
-* `skip-features`
-* `skip-labels`
+To have more fine-grained control over which feature is run/skipped, you can use `WithLabel()` to add labels to your
+tests and use those with the `--labels` and `--skip-labels` CLI flags.
 
 ### Running tests with flags
 
-The tests can be executed using the normal `go test` tools steps. For instance, to pass the flags to your tests, do the followings:
+#### Using `--skip-features`
+
+The tests can be executed using the normal `go test` tools steps. For instance, to skip the `pod list` feature, pass the
+`--skip-features` flag to your tests:
 
 ```shell
 go test -v . -args --skip-features "pod list"
@@ -50,19 +48,45 @@ go test -c -o skipflags.test .
 Then execute the test binary passing the CLI arguments:
 
 ```shell
-./skipflags.test --labels "env=dev"
+./skipflags.test --skip-features "pod list"
 ```
 
-To skip a particular labeled feature , do the following
+#### Using `--labels` and `--skip-labels`
+
+Adding one or more labels to your features using `WithLabels()` gives you more control over which features are executed.
+
+To skip features labeled with `"env"` is `"dev"`:
 
 ```shell
-./skipflags.test --skip-labels "env=prod"
+go test -v . -args --skip-labels=env=dev
 ```
+
+To only run features labeled with `"type"` `"k8score"`:
+
+```shell
+go test -v . -args --labels=type=k8score
+```
+
+To be even more explicit, `--labels` and `--skip-labels` allows for multiple labels to be passed. For example, to run
+all tests labeled with `"type"` `"k8score"` **and** labeled with `"env"` `"prod"`:
+
+```shell
+go test -v . -args --labels=type=k8score,env=prod
+```
+
+You can combine `--labels` and `--skip-labels` for even more control. For example, to run all features labeled with
+`"type"` `"k8score"` but exclude those labeled with `"env"` is `"dev"`:
+
+```shell
+go test -v . -args --labels=type=k8score --skip-labels=env=dev
+```
+
+> **Note**
+> Features without a label or where the specified `--labels` do not exactly match are also excluded from the tests.
 
 ### Skip tests using built in -skip flag in go test 
 
 Go 1.20 introduces the `-skip` flag for `go test` command to skip tests. 
-
 
 Tests can also be skipped based on test function name, feature name and assesment name with `-skip` flag
 
@@ -76,15 +100,14 @@ To skip a test by test function name `TestSkipFlags`, do the following
 go test -v . -skip TestSkipFlags
 ```
 
-
 To skip a feature with name `pod list` within test function `TestSkipFlags`, do the following
 
 ```shell
 go test -v . -skip TestSkipFlags/pod list
 ```
 
-
-To skip a assesment with name `pods from kube-system` within feature `pod list` within test function `TestSkipFlags`,  do the following
+To skip a assesment with name `pods from kube-system` within feature `pod list` within test function `TestSkipFlags`,
+do the following
 
 ```shell
 go test -v . -skip TestSkipFlags/pod list/pods from kube-system
@@ -92,19 +115,20 @@ go test -v . -skip TestSkipFlags/pod list/pods from kube-system
 
 It is not possible to skip features by label name with this option
 
-
 ### Skip tests using both -skip flag and --skip-xxx flags
 
-We can also use the combination of `-skip` flag built in `go test` and `-skip-xxx` flags provided by the e2e-framework to skip multiple tests
+We can also use the combination of `-skip` flag built in `go test` and `-skip-xxx` flags provided by the e2e-framework
+to skip multiple tests
 
-
-To skip a feature `pod list` within test function `TestSkipFlags` and feature `appsv1/deployment` within test function `TestSkipFlags`, do the following
+To skip a feature `pod list` within test function `TestSkipFlags` and feature `appsv1/deployment` within test function
+`TestSkipFlags`, do the following
 
 ```shell
 go test -v . -skip TestSkipFlags/appsv1/deployment -args --skip-features "pod list"
 ```
 
-To skip a particular labeled feature with label `env=prod` and assesment `deployment creation` within feature `appsv1/deployment` within test function `TestSkipFlags`, do the following
+To skip a particular labeled feature with label `env=prod` and assesment `deployment creation` within feature
+`appsv1/deployment` within test function `TestSkipFlags`, do the following
 
 ```shell
 go test -v . -skip TestSkipFlags/appsv1/deployment/deployment_creation -args --skip-labels "env=prod"

--- a/examples/skip_flags/k8s_test.go
+++ b/examples/skip_flags/k8s_test.go
@@ -29,7 +29,9 @@ import (
 )
 
 func TestSkipFlags(t *testing.T) {
-	podFeature := features.New("pod list").WithLabel("env", "prod").
+	podFeature := features.New("pod list").
+		WithLabel("type", "k8score").
+		WithLabel("env", "prod").
 		Assess("pods from kube-system", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			var pods corev1.PodList
 			client, err := cfg.NewClient()
@@ -48,7 +50,9 @@ func TestSkipFlags(t *testing.T) {
 		}).Feature()
 
 	// feature uses pre-generated namespace (see TestMain)
-	depFeature := features.New("appsv1/deployment").WithLabel("env", "dev").
+	depFeature := features.New("appsv1/deployment").
+		WithLabel("type", "k8score").
+		WithLabel("env", "dev").
 		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			// insert a deployment
 			deployment := newDeployment(cfg.Namespace(), "test-deployment", 1)


### PR DESCRIPTION
Follow-up on #194 where the logic was still not correct in all cases. The behavior is now as expected: if `--labels` is specified all keys and values specified must match a feature. This allows for arbitrary and complex combinations of multiple features within one suite.

For example:

```go
f1 := features.New("label demo 1").
		WithLabel("a", "1").
		WithLabel("all", "true").
		Feature()

f2 := features.New("label demo 2").
		WithLabel("all", "true").
		Feature()

f3 := features.New("label demo 3").
		WithLabel("a", "2").
		WithLabel("all", "true").
		Feature()

f4 := features.New("label demo 4").
		WithLabel("a", "1").
		WithLabel("b", "1").
		WithLabel("all", "true").
		Feature()
```

Leads to the following outcomes with different `--labels`:

```console
go test -race -v ./e2e -args -v 4 --labels=some=value
--- PASS: TestDemoE2E (0.07s)
    --- SKIP: TestDemoE2E/label_demo_1 (0.00s)
    --- SKIP: TestDemoE2E/label_demo_2 (0.00s)
    --- SKIP: TestDemoE2E/label_demo_3 (0.00s)
    --- SKIP: TestDemoE2E/label_demo_4 (0.00s)
PASS
```

```console
go test -race -v ./e2e -args -v 4 --labels=a=1
--- PASS: TestDemoE2E (0.06s)
    --- PASS: TestDemoE2E/label_demo_1 (0.00s)
    --- SKIP: TestDemoE2E/label_demo_2 (0.00s)
    --- SKIP: TestDemoE2E/label_demo_3 (0.00s)
    --- PASS: TestDemoE2E/label_demo_4 (0.00s)
PASS
```

```console
go test -race -v ./e2e -args -v 4 --labels=all=true
--- PASS: TestDemoE2E (0.05s)
    --- PASS: TestDemoE2E/label_demo_1 (0.00s)
    --- PASS: TestDemoE2E/label_demo_2 (0.00s)
    --- PASS: TestDemoE2E/label_demo_3 (0.00s)
    --- PASS: TestDemoE2E/label_demo_4 (0.00s)
PASS
```

```console
go test -race -v ./e2e -args -v 4 --labels=all=true,a=1
--- PASS: TestDemoE2E (0.04s)
    --- PASS: TestDemoE2E/label_demo_1 (0.00s)
    --- SKIP: TestDemoE2E/label_demo_2 (0.00s)
    --- SKIP: TestDemoE2E/label_demo_3 (0.00s)
    --- PASS: TestDemoE2E/label_demo_4 (0.00s)
PASS
```

Passing no `--labels` of course works as expected

```console
go test -race -v ./e2e -args -v 4
--- PASS: TestDemoE2E (0.06s)
    --- PASS: TestDemoE2E/label_demo_1 (0.00s)
    --- PASS: TestDemoE2E/label_demo_2 (0.00s)
    --- PASS: TestDemoE2E/label_demo_3 (0.00s)
    --- PASS: TestDemoE2E/label_demo_4 (0.00s)
PASS
```

Also works in combination with `--skip-labels`

```console
go test -race -v ./e2e -args -v 4 --labels=a=1 --skip-labels=all=true
--- PASS: TestDemoE2E (0.05s)
    --- SKIP: TestDemoE2E/label_demo_1 (0.00s)
    --- SKIP: TestDemoE2E/label_demo_2 (0.00s)
    --- SKIP: TestDemoE2E/label_demo_3 (0.00s)
    --- SKIP: TestDemoE2E/label_demo_4 (0.00s)
PASS
```