### PR TITLE
Add condition for checking if a deployment is available

### DIFF
--- a/klient/wait/conditions/conditions.go
+++ b/klient/wait/conditions/conditions.go
@@ -27,6 +27,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apimachinerywait "k8s.io/apimachinery/pkg/util/wait"
 
 	"sigs.k8s.io/e2e-framework/klient/k8s"
@@ -291,4 +292,14 @@ func (c *Condition) JobCompleted(job k8s.Object) apimachinerywait.ConditionWithC
 // v1.ConditionTrue state
 func (c *Condition) JobFailed(job k8s.Object) apimachinerywait.ConditionWithContextFunc {
 	return c.JobConditionMatch(job, batchv1.JobFailed, v1.ConditionTrue)
+}
+
+// DeploymentAvailable is a helper function used to check if the deployment condition appsv1.DeploymentAvailable
+// has reached v1.ConditionTrue state
+func (c *Condition) DeploymentAvailable(name, namespace string) apimachinerywait.ConditionWithContextFunc {
+	return c.DeploymentConditionMatch(
+		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace}},
+		appsv1.DeploymentAvailable,
+		v1.ConditionTrue,
+	)
 }

--- a/klient/wait/wait_test.go
+++ b/klient/wait/wait_test.go
@@ -237,3 +237,12 @@ func TestResourceMatch(t *testing.T) {
 	}
 	log.Info("Done")
 }
+
+func TestDeploymentAvailable(t *testing.T) {
+	var err error
+	deployment := createDeployment("d7", 2, t)
+	err = For(conditions.New(getResourceManager()).DeploymentAvailable(deployment.Name, deployment.Namespace))
+	if err != nil {
+		t.Error("failed waiting for deployment to become available")
+	}
+}


### PR DESCRIPTION
# Change
This PR adds a new condition to check if a deployment is available. The wait condition only requires the user to provide the deployment name and namespace and the condition method will handle building the deployment object/checking the deployment condition for a match.

With this new condition, it will remove the need for the user to build the deployment object and call deployment condition match condition in their code bases.

_Before_

```go
import (
    "os"
    appsv1 "k8s.io/api/apps/v1"
    metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
    "sigs.k8s.io/e2e-framework/klient/wait"
    "sigs.k8s.io/e2e-framework/klient/wait/conditions"
)

deployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "deployment", Namespace: "namespace"}}
err = wait.For(conditions.New(client).DeploymentConditionMatch(deployment, appsv1.DeploymentAvailable, v1.ConditionTrue))
if err != nil {
    fmt.Printf("error waiting for deployment to become available: %v", err)
    os.Exit(1)
}
```

_After_

```go
import (
    "os"
    "sigs.k8s.io/e2e-framework/klient/wait"
    "sigs.k8s.io/e2e-framework/klient/wait/conditions"
)

err = wait.For(conditions.New(client).DeploymentAvailable("deployment", "namespace"))
if err != nil {
    fmt.Printf("error waiting for deployment to become available: %v", err)
    os.Exit(1)
}
```