### PR TITLE
Fix race condition when executing parallel tests

### DIFF
--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -38,5 +38,5 @@ cd "${REPO_ROOT}"
 
 # Ensure -p=1 to avoid packages running concurrently which may all try and install kind at the same time or race for
 # use of the kind binary.
-GO111MODULE=on go test -v -p=1 -timeout="${TEST_TIMEOUT}s" -count=1 -cover -coverprofile coverage.out $(go list ./...)
+GO111MODULE=on go test -race -v -p=1 -timeout="${TEST_TIMEOUT}s" -count=1 -cover -coverprofile coverage.out $(go list ./...)
 go tool cover -html coverage.out -o coverage.html

--- a/pkg/env/env_test.go
+++ b/pkg/env/env_test.go
@@ -18,6 +18,7 @@ package env
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -535,28 +536,37 @@ func TestEnv_Context_Propagation(t *testing.T) {
 
 func TestTestEnv_TestInParallel(t *testing.T) {
 	env := NewParallel()
+	mutex := sync.Mutex{}
 	beforeEachCallCount := 0
 	afterEachCallCount := 0
 	beforeFeatureCount := 0
 	afterFeatureCount := 0
 	env.BeforeEachTest(func(ctx context.Context, config *envconf.Config, t *testing.T) (context.Context, error) {
+		mutex.Lock()
+		defer mutex.Unlock()
 		beforeEachCallCount++
 		return ctx, nil
 	})
 
 	env.AfterEachTest(func(ctx context.Context, config *envconf.Config, t *testing.T) (context.Context, error) {
+		mutex.Lock()
+		defer mutex.Unlock()
 		afterEachCallCount++
 		return ctx, nil
 	})
 
 	env.BeforeEachFeature(func(ctx context.Context, config *envconf.Config, _ *testing.T, feature types.Feature) (context.Context, error) {
 		t.Logf("Running before each feature for feature %s", feature.Name())
+		mutex.Lock()
+		defer mutex.Unlock()
 		beforeFeatureCount++
 		return ctx, nil
 	})
 
 	env.AfterEachFeature(func(ctx context.Context, config *envconf.Config, _ *testing.T, feature types.Feature) (context.Context, error) {
 		t.Logf("Running after each feature for feature %s", feature.Name())
+		mutex.Lock()
+		defer mutex.Unlock()
 		afterFeatureCount++
 		return ctx, nil
 	})

--- a/pkg/env/env_test.go
+++ b/pkg/env/env_test.go
@@ -594,3 +594,26 @@ func TestTestEnv_TestInParallel(t *testing.T) {
 		t.Fatal("BeforeEachTest handler should be invoked only once")
 	}
 }
+
+func TestParallelOne(t *testing.T) {
+	t.Parallel()
+	f := features.New("one").
+		Assess("log a message", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			ns := envconf.RandomName("ns", 20)
+			t.Logf("RandomName: %s", ns)
+			return ctx
+		})
+	envForTesting.Test(t, f.Feature())
+}
+
+func TestParallelTwo(t *testing.T) {
+	t.Parallel()
+	f := features.New("two").
+		Assess("log a message", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			ns := envconf.RandomName("ns", 20)
+			t.Logf("RandomName: %s", ns)
+			return ctx
+		})
+
+	envForTesting.Test(t, f.Feature())
+}

--- a/pkg/internal/types/types.go
+++ b/pkg/internal/types/types.go
@@ -47,9 +47,6 @@ type TestEnvFunc func(context.Context, *envconf.Config, *testing.T) (context.Con
 // Environment represents an environment where
 // features can be tested.
 type Environment interface {
-	// WithContext returns a new Environment with a new context
-	WithContext(context.Context) Environment
-
 	// Setup registers environment operations that are executed once
 	// prior to the environment being ready and prior to any test.
 	Setup(...EnvFunc) Environment
@@ -68,12 +65,12 @@ type Environment interface {
 
 	// Test executes a test feature defined in a TestXXX function
 	// This method surfaces context for further updates.
-	Test(*testing.T, ...Feature)
+	Test(context.Context, *testing.T, ...Feature)
 
 	// TestInParallel executes a series of test features defined in a
 	// TestXXX function in parallel. This works the same way Test method
 	// does with the caveat that the features will all be run in parallel
-	TestInParallel(*testing.T, ...Feature)
+	TestInParallel(context.Context, *testing.T, ...Feature)
 
 	// AfterEachTest registers environment funcs that are executed
 	// after each Env.Test(...).
@@ -84,7 +81,7 @@ type Environment interface {
 	Finish(...EnvFunc) Environment
 
 	// Run Launches the test suite from within a TestMain
-	Run(*testing.M) int
+	Run(context.Context, *testing.M) int
 }
 
 type Labels = flags.LabelsMap


### PR DESCRIPTION
This should fix https://github.com/kubernetes-sigs/e2e-framework/issues/258 and https://github.com/kubernetes-sigs/e2e-framework/issues/216

The issue seems to be we're embedding a context inside `testenv` and when we run multiple tests in parallel we write back to that context from those multiple go routines, causing a data race.

The change I'm proposing is to be explicit and pass a context explicitly to `Run`, `Test` and `TestInParallel`. If the majority of the users care about context propagation because they use it to pass data between tests or their different phases, I think we should provide a thread safe data structure to do so.

I can't reproduce the issue anymore with my example code and the `pkg/env` tests are passing.