### PR TITLE
enable linters of examples and update golangci-lint version

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,7 +30,6 @@ linters:
   enable:
     - asciicheck
     - bodyclose
-    - depguard
     - dogsled
     - dupl
     - errcheck
@@ -62,26 +61,6 @@ linters:
     - whitespace
 
 linters-settings:
-  # Addig the following section based on https://github.com/golangci/golangci-lint/issues/3877
-  depguard:
-    rules:
-      main:
-        files:
-          - $all
-          - "!$test"
-        allow:
-          - $gostd
-          - github.com/vladimirvivien
-          - k8s.io
-          - sigs.k8s.io
-      test:
-        files:
-          - "$test"
-        allow:
-          - $gostd
-          - github.com/vladimirvivien
-          - k8s.io
-          - sigs.k8s.io
   revive:
     confidence: 0.01
     rules:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,6 +2,12 @@
 run:
   concurrency: 6
   deadline: 5m
+  skip-dirs-use-default: false
+  skip-dirs:
+    - (^|/)vendor($|/)
+    - (^|/)testdata($|/)
+    - (^|/)Godeps($|/)
+    - (^|/)builtin($|/)
 issues:
   exclude-rules:
     # counterfeiter fakes are usually named 'fake_<something>.go'
@@ -10,6 +16,15 @@ issues:
         - gocritic
         - golint
         - dupl
+    - path: examples/*
+      linters:
+        - gocritic
+        - golint
+        - dupl
+        - staticcheck
+        - goconst
+        - errcheck
+        - stylecheck  #Since Example packages have _ in them this will break a bunch of tests unless we rename all of those packages
 linters:
   disable-all: true
   enable:
@@ -47,6 +62,32 @@ linters:
     - whitespace
 
 linters-settings:
+  # Addig the following section based on https://github.com/golangci/golangci-lint/issues/3877
+  depguard:
+    rules:
+      main:
+        files:
+          - $all
+          - "!$test"
+        allow:
+          - $gostd
+          - github.com/vladimirvivien
+          - k8s.io
+          - sigs.k8s.io
+      test:
+        files:
+          - "$test"
+        allow:
+          - $gostd
+          - github.com/vladimirvivien
+          - k8s.io
+          - sigs.k8s.io
+  revive:
+    confidence: 0.01
+    rules:
+      - name: duplicated-imports
+        severity: error
+        disabled: false
   godox:
     keywords:
       - BUG

--- a/examples/crds/main_test.go
+++ b/examples/crds/main_test.go
@@ -43,8 +43,8 @@ func TestMain(m *testing.M) {
 		envfuncs.CreateKindCluster(kindClusterName),
 		envfuncs.SetupCRDs("./testdata/crds", "*"),
 		envfuncs.CreateNamespace(namespace),
-		func(ctx context.Context, c *envconf.Config) (context.Context, error) {
-			// I have notiecd a lot timing issue with this tests where the actual assessment fails becuase
+		func(ctx context.Context, _ *envconf.Config) (context.Context, error) {
+			// I have notiecd a lot timing issue with this tests where the actual assessment fails because
 			// unable to retrieve the complete list of server APIs: stable.example.com/v1: the server could not find the requested resource
 			// But when you manually check, the resource exists. Just that the tests are running a bit too quick and API server has not
 			// yet started serving the request it seems like. Since there is no clear way today for us to use wait condition directly to

--- a/examples/dry_run/main_test.go
+++ b/examples/dry_run/main_test.go
@@ -24,9 +24,7 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 )
 
-var (
-	testEnv env.Environment
-)
+var testEnv env.Environment
 
 func TestMain(m *testing.M) {
 	cfg, _ := envconf.NewFromFlags()

--- a/examples/every_test_custom_ns/main_test.go
+++ b/examples/every_test_custom_ns/main_test.go
@@ -30,8 +30,10 @@ import (
 	"sigs.k8s.io/e2e-framework/support/kind"
 )
 
-type NamespaceCtxKey string
-type ClusterCtxKey string
+type (
+	NamespaceCtxKey string
+	ClusterCtxKey   string
+)
 
 var testenv env.Environment
 
@@ -60,7 +62,7 @@ func TestMain(m *testing.M) {
 			return context.WithValue(ctx, ClusterCtxKey("cluster"), cluster), nil
 		}).Finish(
 		// Teardown func: delete kind cluster
-		func(ctx context.Context, cfg *envconf.Config) (context.Context, error) {
+		func(ctx context.Context, _ *envconf.Config) (context.Context, error) {
 			cluster := ctx.Value(ClusterCtxKey("cluster")).(*kind.Cluster) // nil should be tested
 			if cluster == nil {
 				return ctx, fmt.Errorf("error getting kind cluster from context")
@@ -95,7 +97,7 @@ func createNSForTest(ctx context.Context, cfg *envconf.Config, t *testing.T, run
 }
 
 // DeleteNSForTest looks up the namespace corresponding to the given test and deletes it.
-func deleteNSForTest(ctx context.Context, cfg *envconf.Config, t *testing.T, runID string) (context.Context, error) {
+func deleteNSForTest(ctx context.Context, cfg *envconf.Config, t *testing.T, _ string) (context.Context, error) {
 	ns := fmt.Sprint(ctx.Value(GetNamespaceKey(t)))
 	t.Logf("Deleting NS %v for test %v", ns, t.Name())
 

--- a/examples/flags/flags_test.go
+++ b/examples/flags/flags_test.go
@@ -45,15 +45,15 @@ var test env.Environment
 //
 // Pass flags in couple of ways:
 //
-//   go test -v . -args --assess en
+//	go test -v . -args --assess en
 //
 // Or, build a test binary first:
 //
-//   go test -c -o flags.test .
+//	go test -c -o flags.test .
 //
 // Then, execute the test:
 //
-//  ./flags.test --assess en
+//	./flags.test --assess en
 func TestMain(m *testing.M) {
 	// create config from flags (always in TestMain because it calls flag.Parse())
 	cfg, err := envconf.NewFromFlags()

--- a/examples/pod_exec/envtest_test.go
+++ b/examples/pod_exec/envtest_test.go
@@ -43,7 +43,7 @@ func TestExecPod(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if err := client.Resources().Create(ctx, deployment); err != nil {
+			if err = client.Resources().Create(ctx, deployment); err != nil {
 				t.Fatal(err)
 			}
 			err = wait.For(conditions.New(client.Resources()).DeploymentConditionMatch(deployment, appsv1.DeploymentAvailable, corev1.ConditionTrue), wait.WithTimeout(time.Minute*5))
@@ -54,7 +54,6 @@ func TestExecPod(t *testing.T) {
 			return ctx
 		}).
 		Assess("check connectivity to wikipedia.org main page", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
-
 			client, err := c.NewClient()
 			if err != nil {
 				t.Fatal(err)
@@ -82,6 +81,7 @@ func TestExecPod(t *testing.T) {
 		}).Feature()
 	testEnv.Test(t, feature)
 }
+
 func newDeployment(namespace string, name string, replicas int32, containerName string) *appsv1.Deployment {
 	labels := map[string]string{"app": "pod-exec"}
 	return &appsv1.Deployment{

--- a/examples/real_cluster/main_test.go
+++ b/examples/real_cluster/main_test.go
@@ -22,11 +22,12 @@ import (
 	//_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"   // auth for GKE clusters
 	//_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"  // auth for OIDC
 	"os"
+	"testing"
+
 	"sigs.k8s.io/e2e-framework/klient/conf"
 	"sigs.k8s.io/e2e-framework/pkg/env"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/envfuncs"
-	"testing"
 )
 
 var testenv env.Environment

--- a/examples/third_party_integration/helm/helm_test.go
+++ b/examples/third_party_integration/helm/helm_test.go
@@ -18,7 +18,6 @@ package helm
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -32,8 +31,6 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/features"
 	"sigs.k8s.io/e2e-framework/third_party/helm"
 )
-
-var curDir, _ = os.Getwd()
 
 func TestHelmChartRepoWorkflow(t *testing.T) {
 	feature := features.New("Repo based helm chart workflow").

--- a/examples/third_party_integration/helm/main_test.go
+++ b/examples/third_party_integration/helm/main_test.go
@@ -29,9 +29,15 @@ var (
 	testEnv         env.Environment
 	namespace       string
 	kindClusterName string
+	curDir          string
 )
 
 func TestMain(m *testing.M) {
+	c, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
+	curDir = c
 	cfg, _ := envconf.NewFromFlags()
 	testEnv = env.NewWithConfig(cfg)
 	kindClusterName = envconf.RandomName("third-party", 16)

--- a/examples/watch_resources/watch_test.go
+++ b/examples/watch_resources/watch_test.go
@@ -44,7 +44,7 @@ func TestWatchForResources(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "watch-dep", Namespace: cfg.Namespace()},
 			}
 
-			// watch for the deployment and triger action based on the event recieved.
+			// watch for the deployment and triger action based on the event received.
 			cl.Resources().Watch(&appsv1.DeploymentList{}, resources.WithFieldSelector(labels.FormatLabels(map[string]string{"metadata.name": dep.Name}))).
 				WithAddFunc(onAdd).WithDeleteFunc(onDelete).Start(ctx)
 
@@ -75,10 +75,9 @@ func TestWatchForResources(t *testing.T) {
 		}).Feature()
 
 	testenv.Test(t, watchFeature)
-
 }
 
-// TestWatchForResourcesWithStop() demonstartes how to start and stop the watcher
+// TestWatchForResourcesWithStop() demonstrates how to start and stop the watcher
 var w *watcher.EventHandlerFuncs
 
 func TestWatchForResourcesWithStop(t *testing.T) {
@@ -93,7 +92,7 @@ func TestWatchForResourcesWithStop(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "watchnstop-dep", Namespace: cfg.Namespace()},
 			}
 
-			// watch for the deployment and triger action based on the event recieved.
+			// watch for the deployment and triger action based on the event received.
 			w = cl.Resources().Watch(&appsv1.DeploymentList{}, resources.WithFieldSelector(labels.FormatLabels(map[string]string{"metadata.name": dep.Name}))).
 				WithAddFunc(onAdd).WithDeleteFunc(onDelete)
 
@@ -132,7 +131,6 @@ func TestWatchForResourcesWithStop(t *testing.T) {
 		}).Feature()
 
 	testenv.Test(t, watchFeature)
-
 }
 
 func TestWatchForResources1(t *testing.T) {
@@ -165,7 +163,7 @@ func TestWatchForResources1(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "demo-app", Namespace: cfg.Namespace()},
 			}
 
-			// watch for the deployment and triger action based on the event recieved.
+			// watch for the deployment and triger action based on the event received.
 			w = cl.Resources().Watch(&appsv1.DeploymentList{}, resources.WithFieldSelector(labels.FormatLabels(map[string]string{"metadata.name": dep.Name}))).
 				WithAddFunc(onAddfunc).WithDeleteFunc(onDelfunc)
 
@@ -192,7 +190,7 @@ func TestWatchForResources1(t *testing.T) {
 			case <-time.After(3 * time.Second):
 				t.Error("Add callback not called")
 			case <-addWait:
-				klog.InfoS("recieved signal, closing add channel")
+				klog.InfoS("received signal, closing add channel")
 				close(addWait)
 			}
 
@@ -213,7 +211,7 @@ func TestWatchForResources1(t *testing.T) {
 			case <-time.After(3 * time.Second):
 				t.Error("Delete callback not called")
 			case <-delWait:
-				klog.InfoS("recieved signal, closing delete channel")
+				klog.InfoS("received signal, closing delete channel")
 				close(delWait)
 			}
 

--- a/hack/verify-golangci-lint.sh
+++ b/hack/verify-golangci-lint.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-VERSION=v1.52.0
+VERSION=v1.53.3
 URL_BASE=https://raw.githubusercontent.com/golangci/golangci-lint
 URL=$URL_BASE/$VERSION/install.sh
 


### PR DESCRIPTION
Enabling linters on the `example/**` components so that they can be linted alongside the other packages codes.

Along with that, this PR also bumps up the `golangci-lint` version and sets-up the `depguard` linter config for allowed packages under tests and main

Closes #280
