### PR TITLE
Fix race condition when executing parallel tests, keeping context

### DIFF
--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -38,5 +38,5 @@ cd "${REPO_ROOT}"
 
 # Ensure -p=1 to avoid packages running concurrently which may all try and install kind at the same time or race for
 # use of the kind binary.
-GO111MODULE=on go test -v -p=1 -timeout="${TEST_TIMEOUT}s" -count=1 -cover -coverprofile coverage.out $(go list ./...)
+GO111MODULE=on go test -race -v -p=1 -timeout="${TEST_TIMEOUT}s" -count=1 -cover -coverprofile coverage.out $(go list ./...)
 go tool cover -html coverage.out -o coverage.html


### PR DESCRIPTION
This is another approach to solve the same problem as #265 and was developed with the help of @maruina.

This patch makes the context in the testEnv thread safe, but implements the following logic:

- If `Test` is used, the same logic of now applies. So the context is passed to all features being run sequentially and is then reinjected into the environment.
- If `TestInParallel` is used (and parallel tests are enabled), the context is first populated by the `BeforeEachTest` functions and then a dedicated child of the parent context is provided to each test running in parallel, which is then discarded and only the original parent context is passed to the `AfterEachTest` functions and back into the environment. This is actually fixing a race condition in the previous implementation of `TestInParallel`.
- If `t.Parallel` is used to run one or more features either using `Test` or `TestInParallel`, the same logic above applies, with the exception that multiple tests will be accessing the same context in the BeforeEachTest and AfterEachTest functions, and given that the update of the context is done by substitution and is not atomic, the order, and therefore the outcome, is non-deterministic. So it's up to the user to define a dedicated context for each test in this case.