### PR TITLE
Fix race condition when executing parallel tests, passing context down and back

### DIFF
--- a/examples/crds/envtest_test.go
+++ b/examples/crds/envtest_test.go
@@ -64,5 +64,5 @@ func TestCRDSetup(t *testing.T) {
 			return ctx
 		}).Feature()
 
-	testEnv.Test(t, feature)
+	_ = testEnv.Test(t, feature)
 }

--- a/examples/dry_run/dry_run_test.go
+++ b/examples/dry_run/dry_run_test.go
@@ -46,7 +46,7 @@ func TestDryRunOne(t *testing.T) {
 			return ctx
 		}).Feature()
 
-	testEnv.TestInParallel(t, f1, f2)
+	_ = testEnv.TestInParallel(t, f1, f2)
 }
 
 func TestDryRunTwo(t *testing.T) {

--- a/examples/multi_cluster/deployment_test.go
+++ b/examples/multi_cluster/deployment_test.go
@@ -92,5 +92,5 @@ func TestScenarioOne(t *testing.T) {
 		}).
 		Feature()
 
-	testEnv.Test(t, feature)
+	_ = testEnv.Test(t, feature)
 }

--- a/examples/parallel_features/parallel_features_test.go
+++ b/examples/parallel_features/parallel_features_test.go
@@ -118,5 +118,5 @@ func TestPodBringUp(t *testing.T) {
 			return ctx
 		}).Feature()
 
-	testEnv.TestInParallel(t, featureOne, featureTwo)
+	_ = testEnv.TestInParallel(t, featureOne, featureTwo)
 }

--- a/examples/pod_exec/envtest_test.go
+++ b/examples/pod_exec/envtest_test.go
@@ -79,7 +79,7 @@ func TestExecPod(t *testing.T) {
 			}
 			return ctx
 		}).Feature()
-	testEnv.Test(t, feature)
+	_ = testEnv.Test(t, feature)
 }
 
 func newDeployment(namespace string, name string, replicas int32, containerName string) *appsv1.Deployment {

--- a/examples/third_party_integration/helm/helm_test.go
+++ b/examples/third_party_integration/helm/helm_test.go
@@ -87,7 +87,7 @@ func TestHelmChartRepoWorkflow(t *testing.T) {
 			return ctx
 		}).Feature()
 
-	testEnv.Test(t, feature)
+	_ = testEnv.Test(t, feature)
 }
 
 func TestLocalHelmChartWorkflow(t *testing.T) {
@@ -125,5 +125,5 @@ func TestLocalHelmChartWorkflow(t *testing.T) {
 			return ctx
 		}).Feature()
 
-	testEnv.Test(t, feature)
+	_ = testEnv.Test(t, feature)
 }

--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -38,5 +38,5 @@ cd "${REPO_ROOT}"
 
 # Ensure -p=1 to avoid packages running concurrently which may all try and install kind at the same time or race for
 # use of the kind binary.
-GO111MODULE=on go test -v -p=1 -timeout="${TEST_TIMEOUT}s" -count=1 -cover -coverprofile coverage.out $(go list ./...)
+GO111MODULE=on go test -race -v -p=1 -timeout="${TEST_TIMEOUT}s" -count=1 -cover -coverprofile coverage.out $(go list ./...)
 go tool cover -html coverage.out -o coverage.html

--- a/pkg/env/main_test.go
+++ b/pkg/env/main_test.go
@@ -75,6 +75,15 @@ func TestMain(m *testing.M) {
 		}
 		val = append(val, "after-each-test")
 		return context.WithValue(ctx, &ctxTestKeyString{}, val), nil
+	}).Finish(func(ctx context.Context, _ *envconf.Config) (context.Context, error) {
+		// update after the test suite
+		val, ok := ctx.Value(&ctxTestKeyString{}).([]string)
+		if !ok {
+			log.Fatal("context value was not of expected type []string] or nil")
+		}
+		// this will only be accessible after the whole suite run
+		val = append(val, "finish")
+		return context.WithValue(ctx, &ctxTestKeyString{}, val), nil
 	})
 
 	os.Exit(envForTesting.Run(m))

--- a/pkg/internal/types/types.go
+++ b/pkg/internal/types/types.go
@@ -68,12 +68,12 @@ type Environment interface {
 
 	// Test executes a test feature defined in a TestXXX function
 	// This method surfaces context for further updates.
-	Test(*testing.T, ...Feature)
+	Test(*testing.T, ...Feature) context.Context
 
 	// TestInParallel executes a series of test features defined in a
 	// TestXXX function in parallel. This works the same way Test method
 	// does with the caveat that the features will all be run in parallel
-	TestInParallel(*testing.T, ...Feature)
+	TestInParallel(*testing.T, ...Feature) context.Context
 
 	// AfterEachTest registers environment funcs that are executed
 	// after each Env.Test(...).


### PR DESCRIPTION
This is another approach to solve the same problem as https://github.com/kubernetes-sigs/e2e-framework/pull/265 and was developed with the help of @maruina.

Supersedes https://github.com/kubernetes-sigs/e2e-framework/pull/291 as I think is a better approach w.r.t. the one proposed there.

This patch reduces the number of accesses to the context in the testEnv to only the ones that are strictly necessary and that should be synchronous. So, testEnv still contains a ctx, but is only to be used as a starting point and won't be updated except after the setup and finish phase.

According to the following logic:

- If `Test` is used, the same logic of now applies. So the context is passed to all features being run sequentially and the most updated version is then returned to the caller.
- If `TestInParallel` is used (and parallel tests are enabled), the context is first populated by the `BeforeEachTest` functions and then a dedicated child of the parent context is provided to each test running in parallel, which is then discarded and only the original parent context is passed to the `AfterEachTest` functions and back into the environment. This is actually fixing a race condition in the previous implementation of `TestInParallel`.
- If `t.Parallel` is used to run one or more features either using `Test` or `TestInParallel`, the same logic above applies, given that each caller will get its own context back.

The only caveat is that the context is that the Finish phase will only be able to see the context from the Setup phase and not the one from the features themselves.