### PR TITLE
show stacktrace when panic in env.Setup

### DIFF
--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"runtime/debug"
 	"sync"
 	"testing"
 
@@ -346,7 +347,7 @@ func (e *testEnv) Run(m *testing.M) int {
 			if e.cfg.DisableGracefulTeardown() {
 				panic(rErr)
 			}
-			klog.Error("Recovering from panic and running finish actions", rErr)
+			klog.Errorf("Recovering from panic and running finish actions", rErr, string(debug.Stack()))
 		}
 
 		finishes := e.getFinishActions()

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -347,7 +347,7 @@ func (e *testEnv) Run(m *testing.M) int {
 			if e.cfg.DisableGracefulTeardown() {
 				panic(rErr)
 			}
-			klog.Errorf("Recovering from panic and running finish actions", rErr, string(debug.Stack()))
+			klog.Errorf("Recovering from panic and running finish actions: %s, stack: %s", rErr, string(debug.Stack()))
 		}
 
 		finishes := e.getFinishActions()


### PR DESCRIPTION
fixes https://github.com/kubernetes-sigs/e2e-framework/issues/289 by adding stacktrace 