### PR TITLE
Validate kindConfigFile while configuring Kind cluster

### DIFF
--- a/support/kind/kind.go
+++ b/support/kind/kind.go
@@ -146,7 +146,10 @@ func (k *Cluster) clusterExists(name string) (string, bool) {
 }
 
 func (k *Cluster) CreateWithConfig(ctx context.Context, kindConfigFile string) (string, error) {
-	args := []string{"--config", kindConfigFile}
+	var args []string
+	if kindConfigFile != "" {
+		args = append(args, "--config", kindConfigFile)
+	}
 	if k.image != "" {
 		args = append(args, "--image", k.image)
 	}

--- a/support/kwok/kwok.go
+++ b/support/kwok/kwok.go
@@ -156,6 +156,10 @@ func (k *Cluster) Create(ctx context.Context, args ...string) (string, error) {
 }
 
 func (k *Cluster) CreateWithConfig(ctx context.Context, configFile string) (string, error) {
+	if configFile == "" {
+		return k.Create(ctx)
+	}
+
 	return k.Create(ctx, "--config", configFile)
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR fix the situation, when someone would like to create Kind cluster with options, but without `kindConfigFile` defined, i.e.
```golang
envfuncs.CreateClusterWithConfig(kind.NewProvider(), kindClusterName, "", kind.WithImage("kindest/node:v1.22.2")),
```

In this case, create procedure will fails with unpredictable behavior:
```shell
15:14 $ make e2e 
go test ./test/e2e/... --v 4
F0906 15:17:25.100154   88839 env.go:375] Setup failure: failed to create kind cluster: exit status 1 : exit status 1: ERROR: unknown command "kindest/node:v1.27.3" for "kind create cluster"
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter the details of what chanages are being introduced:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
```


#### Additional documentation e.g., Usage docs, etc.:

<!--
When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```