### PR TITLE
bugfix MutateAnnotations

### DIFF
--- a/klient/decoder/decoder.go
+++ b/klient/decoder/decoder.go
@@ -254,7 +254,7 @@ func MutateAnnotations(overrides map[string]string) DecodeOption {
 		annotations := obj.GetAnnotations()
 		if annotations == nil {
 			annotations = make(map[string]string)
-			obj.SetLabels(annotations)
+			obj.SetAnnotations(annotations)
 		}
 		for key, value := range overrides {
 			annotations[key] = value

--- a/klient/decoder/decoder_test.go
+++ b/klient/decoder/decoder_test.go
@@ -32,6 +32,7 @@ import (
 )
 
 const (
+	testAnnotation       = "annotationvalue"
 	testLabel            = "labelvalue"
 	serviceAccountPrefix = "example-sa*"
 )
@@ -253,6 +254,26 @@ func TestDecodersWithMutateFunc(t *testing.T) {
 			t.Fatal(err)
 		}
 	})
+}
+
+func TestMutateAnnotations(t *testing.T) {
+	testObj := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{"injected": "original"},
+		},
+	}
+	options := &decoder.Options{}
+	opt := decoder.MutateAnnotations(map[string]string{"injected": testAnnotation})
+	opt(options)
+	for _, fn := range options.MutateFuncs {
+		if err := fn(testObj); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if testObj.Annotations["injected"] != testAnnotation {
+		t.Fatal("expected object annotation to be overwritten")
+	}
 }
 
 func TestHandlerFuncs(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Previously, if an object has no annotations, new annotations would be created and set as the label, and then overrides would be set on the labels.

#### Does this PR introduce a user-facing change?

```release-note
fixed an issue with MutateAnnotations when the object had no existing annotations
```
