### PR TITLE
fix: fix RandomName's dash when no prefix provided

### DIFF
--- a/pkg/envconf/config.go
+++ b/pkg/envconf/config.go
@@ -303,5 +303,8 @@ func RandomName(prefix string, n int) string {
 	rand.Seed(time.Now().UnixNano())
 	p := make([]byte, n)
 	rand.Read(p)
+	if prefix == "" {
+		return hex.EncodeToString(p)[:n]
+	}
 	return fmt.Sprintf("%s-%s", prefix, hex.EncodeToString(p))[:n]
 }

--- a/pkg/envconf/config_test.go
+++ b/pkg/envconf/config_test.go
@@ -18,7 +18,6 @@ package envconf
 
 import (
 	"flag"
-	"math/rand"
 	"os"
 	"strings"
 	"testing"
@@ -89,17 +88,15 @@ func TestConfig_New_WithIgnorePanicRecovery(t *testing.T) {
 }
 
 func TestRandomName(t *testing.T) {
-	const maxLen = 64
-
 	t.Run("no prefix yields random name without dash", func(t *testing.T) {
-		out := RandomName("", int(rand.Int31n(maxLen)))
+		out := RandomName("", 16)
 		if strings.Contains(out, "-") {
 			t.Errorf("random name %q shouldn't contain a dash when no prefix provided", out)
 		}
 	})
 
 	t.Run("non empty prefix yields random name with dash", func(t *testing.T) {
-		out := RandomName("abc", int(rand.Int31n(maxLen)))
+		out := RandomName("abc", 16)
 		if !strings.Contains(out, "-") {
 			t.Errorf("random name %q should contain a dash when prefix provided", out)
 		}

--- a/pkg/envconf/config_test.go
+++ b/pkg/envconf/config_test.go
@@ -18,7 +18,9 @@ package envconf
 
 import (
 	"flag"
+	"math/rand"
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -84,4 +86,22 @@ func TestConfig_New_WithIgnorePanicRecovery(t *testing.T) {
 	if !cfg.DisableGracefulTeardown() {
 		t.Error("expected ignore-panic-recovery mode to be enabled when -disable-graceful-teardown argument is passed")
 	}
+}
+
+func TestRandomName(t *testing.T) {
+	const maxLen = 64
+
+	t.Run("no prefix yields random name without dash", func(t *testing.T) {
+		out := RandomName("", int(rand.Int31n(maxLen)))
+		if strings.Contains(out, "-") {
+			t.Errorf("random name %q shouldn't contain a dash when no prefix provided", out)
+		}
+	})
+
+	t.Run("non empty prefix yields random name with dash", func(t *testing.T) {
+		out := RandomName("abc", int(rand.Int31n(maxLen)))
+		if !strings.Contains(out, "-") {
+			t.Errorf("random name %q should contain a dash when prefix provided", out)
+		}
+	})
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:

Currently `envconf.RandomName()` return a string with an empty prefix when no prefix was provided even though the godoc states:

```
If prefix is omitted, the then entire name is random char.
```

This PR fixes it by checking if an empty prefix was provided.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter the details of what chanages are being introduced:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fixes `envconfg.RandomName() returning a string beginning with `-` when an empty prefix is provided
```


#### Additional documentation e.g., Usage docs, etc.:

<!--
When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```