### PR TITLE
Add conditions.DaemonSetReady

### DIFF
--- a/klient/wait/conditions/conditions.go
+++ b/klient/wait/conditions/conditions.go
@@ -303,3 +303,17 @@ func (c *Condition) DeploymentAvailable(name, namespace string) apimachinerywait
 		v1.ConditionTrue,
 	)
 }
+
+// DaemonSetReady is a helper function used to check if a daemonset's pods are scheduled and ready
+func (c *Condition) DaemonSetReady(daemonset k8s.Object) apimachinerywait.ConditionWithContextFunc {
+	return func(ctx context.Context) (done bool, err error) {
+		if err := c.resources.Get(ctx, daemonset.GetName(), daemonset.GetNamespace(), daemonset); err != nil {
+			return false, err
+		}
+		status := daemonset.(*appsv1.DaemonSet).Status
+		if status.NumberReady == status.DesiredNumberScheduled && status.NumberUnavailable == 0 {
+			done = true
+		}
+		return
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds a `conditions` helper for a `DaemonSet` that asserts its pods are scheduled and ready.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Added `conditions.DaemonSetReady`, a wait helper for determining a DaemonSet is ready.
```

#### Additional documentation e.g., Usage docs, etc.:
