### PR TITLE
Add --cluster-provider-option flag

### DIFF
--- a/pkg/envconf/config.go
+++ b/pkg/envconf/config.go
@@ -36,15 +36,16 @@ type Config struct {
 	namespace               string
 	assessmentRegex         *regexp.Regexp
 	featureRegex            *regexp.Regexp
-	labels                  flags.LabelsMap
+	labels                  flags.FlagMap
 	skipFeatureRegex        *regexp.Regexp
-	skipLabels              flags.LabelsMap
+	skipLabels              flags.FlagMap
 	skipAssessmentRegex     *regexp.Regexp
 	parallelTests           bool
 	dryRun                  bool
 	failFast                bool
 	disableGracefulTeardown bool
 	kubeContext             string
+	clusterProviderOptions  flags.FlagMap
 }
 
 // New creates and initializes an empty environment configuration
@@ -87,6 +88,7 @@ func NewFromFlags() (*Config, error) {
 	e.failFast = envFlags.FailFast()
 	e.disableGracefulTeardown = envFlags.DisableGracefulTeardown()
 	e.kubeContext = envFlags.KubeContext()
+	e.clusterProviderOptions = envFlags.ClusterProviderOptions()
 
 	return e, nil
 }
@@ -285,6 +287,17 @@ func (c *Config) WithKubeContext(kubeContext string) *Config {
 // WithKubeContext is used to get the kubeconfig context
 func (c *Config) KubeContext() string {
 	return c.kubeContext
+}
+
+// WithClusterProviderOptions sets the environment's cluster provider options
+func (c *Config) WithClusterProviderOptions(opts map[string][]string) *Config {
+	c.clusterProviderOptions = opts
+	return c
+}
+
+// ClusterProviderOptions returns the environment's cluster provider options
+func (c *Config) ClusterProviderOptions() map[string][]string {
+	return c.clusterProviderOptions
 }
 
 func randNS() string {

--- a/pkg/internal/types/types.go
+++ b/pkg/internal/types/types.go
@@ -87,7 +87,7 @@ type Environment interface {
 	Run(*testing.M) int
 }
 
-type Labels = flags.LabelsMap
+type Labels = flags.FlagMap
 
 type Feature interface {
 	// Name is a descriptive text for the feature


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind api-change

#### What this PR does / why we need it:

This adds a `--cluster-provider-option` flag that functions the same as `--labels`, to be used to pass arbitrary options to a test's `support.E2EClusterProvider`.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
I think swapping `flags.FlagMap` in for `flags.LabelsMap` is safe, because while it's a public type, the `envconf` functions return a bare map (and so don't change). If there's a concern about breakage, I can try to alias the type.

#### Does this PR introduce a user-facing change?
```release-note
Add `--cluster-provider-option` flag for passing arbitrary options to a test's cluster provider.
```


#### Additional documentation e.g., Usage docs, etc.:
NONE