### PR TITLE
Updates on golang / golangci-lint and dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,11 +8,21 @@ updates:
       - "area/dependency"
       - "release-note-none"
       - "ok-to-test"
+    groups:
+      all:
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-        interval: "daily"
+      interval: "daily"
     labels:
       - "area/dependency"
       - "release-note-none"
       - "ok-to-test"
+    groups:
+      all:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: '1.20'
+          go-version: '1.21'
           check-latest: true
 
       - name: Run GoReleaser

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/e2e-framework
 
-go 1.19
+go 1.20
 
 require (
 	github.com/vladimirvivien/gexe v0.2.0

--- a/hack/verify-golangci-lint.sh
+++ b/hack/verify-golangci-lint.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-VERSION=v1.53.3
+VERSION=v1.55.2
 URL_BASE=https://raw.githubusercontent.com/golangci/golangci-lint
 URL=$URL_BASE/$VERSION/install.sh
 

--- a/pkg/envconf/config.go
+++ b/pkg/envconf/config.go
@@ -300,9 +300,9 @@ func RandomName(prefix string, n int) string {
 	if len(prefix) >= n {
 		return prefix
 	}
-	rand.Seed(time.Now().UnixNano())
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	p := make([]byte, n)
-	rand.Read(p)
+	r.Read(p)
 	if prefix == "" {
 		return hex.EncodeToString(p)[:n]
 	}


### PR DESCRIPTION
#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:

- Updates on golang / golangci-lint and dependabot

test-infra PR to update go: https://github.com/kubernetes/test-infra/pull/31251

#### Which issue(s) this PR fixes:
NONE

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter the details of what chanages are being introduced:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```


#### Additional documentation e.g., Usage docs, etc.:

<!--
When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```