### PR TITLE
Fix timeout with context for wait

### DIFF
--- a/klient/wait/wait.go
+++ b/klient/wait/wait.go
@@ -97,11 +97,13 @@ func For(conditionFunc apimachinerywait.ConditionWithContextFunc, opts ...Option
 	}
 
 	if options.Ctx == nil {
-		options.Ctx, cancel = context.WithTimeout(context.Background(), options.Timeout)
+		options.Ctx = context.Background()
+	}
+
+	if options.Timeout != 0 {
+		options.Ctx, cancel = context.WithTimeout(options.Ctx, options.Timeout)
 		defer cancel()
 	}
-	if options.Immediate {
-		return apimachinerywait.PollUntilContextCancel(options.Ctx, options.Interval, true, conditionFunc)
-	}
-	return apimachinerywait.PollUntilContextCancel(options.Ctx, options.Interval, false, conditionFunc)
+
+	return apimachinerywait.PollUntilContextCancel(options.Ctx, options.Interval, options.Immediate, conditionFunc)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

``` golang
err = wait.For(
	func(ctx context.Context) (done bool, err error) {
		...
	},
	wait.WithContext(ctx),
	wait.WithTimeout(600*time.Second),
)
```

The timeout is ignored when both context and timeout are specified

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter the details of what chanages are being introduced:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```


#### Additional documentation e.g., Usage docs, etc.:

<!--
When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```