### PR TITLE
After setup error, do klog.Error not klog.Fatal, and move on

### DIFF
--- a/examples/graceful_setup_fail/main_test.go
+++ b/examples/graceful_setup_fail/main_test.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package setupfail
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/e2e-framework/pkg/env"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+)
+
+func TestMain(m *testing.M) {
+	var testEnv env.Environment
+
+	tests := []struct {
+		name             string
+		testEnvGenerator func(context.Context, *[]string) env.Environment
+		expected         []string
+	}{
+		{
+			name: "No test setup failures, do all setup and finish actions",
+			testEnvGenerator: func(ctx context.Context, actions *[]string) env.Environment {
+				testEnv = env.New()
+
+				testEnv.Setup(
+					func(ctx context.Context, _ *envconf.Config) (context.Context, error) {
+						*actions = append(*actions, "completed setup 1")
+						return ctx, nil
+					},
+					func(ctx context.Context, _ *envconf.Config) (context.Context, error) {
+						*actions = append(*actions, "completed setup 2")
+						return ctx, nil
+					},
+					func(ctx context.Context, _ *envconf.Config) (context.Context, error) {
+						*actions = append(*actions, "completed setup 3")
+						return ctx, nil
+					},
+				)
+				testEnv.Finish(
+					func(ctx context.Context, _ *envconf.Config) (context.Context, error) {
+						*actions = append(*actions, "completed finish 1")
+						return ctx, nil
+					},
+					func(ctx context.Context, _ *envconf.Config) (context.Context, error) {
+						*actions = append(*actions, "completed finish 2")
+						return ctx, nil
+					},
+				)
+
+				return testEnv
+			},
+			expected: []string{"completed setup 1", "completed setup 2", "completed setup 3", "completed finish 1", "completed finish 2"},
+		},
+		{
+			name: "Skip remaining setup actions after one fails, do finish actions",
+			testEnvGenerator: func(ctx context.Context, actions *[]string) env.Environment {
+				testEnv = env.New()
+
+				testEnv.Setup(
+					func(ctx context.Context, _ *envconf.Config) (context.Context, error) {
+						*actions = append(*actions, "completed setup 1")
+						return ctx, nil
+					},
+					func(ctx context.Context, _ *envconf.Config) (context.Context, error) {
+						*actions = append(*actions, "completed setup 2")
+						return ctx, fmt.Errorf("failed setup 2")
+					},
+					func(ctx context.Context, _ *envconf.Config) (context.Context, error) {
+						*actions = append(*actions, "completed setup 3")
+						return ctx, nil
+					},
+				)
+				testEnv.Finish(
+					func(ctx context.Context, _ *envconf.Config) (context.Context, error) {
+						*actions = append(*actions, "completed finish 1")
+						return ctx, nil
+					},
+					func(ctx context.Context, _ *envconf.Config) (context.Context, error) {
+						*actions = append(*actions, "completed finish 2")
+						return ctx, nil
+					},
+				)
+
+				return testEnv
+			},
+			expected: []string{"completed setup 1", "completed setup 2", "completed finish 1", "completed finish 2"},
+		},
+	}
+
+	for _, test := range tests {
+		var actions []string
+		testEnv = test.testEnvGenerator(context.TODO(), &actions)
+		_ = testEnv.Run(m)
+
+		readableActions := strings.Join(actions, ", ")
+		if len(actions) != len(test.expected) {
+			klog.Fatalf("Expected slice of %v, but got %s", test.expected, readableActions)
+		}
+
+		for i := range actions {
+			if actions[i] != test.expected[i] {
+				klog.Fatalf("Expected slice of %v, but got %s", test.expected, readableActions)
+			}
+		}
+
+		klog.Infof("PASS: %s\n\tActions completed: %+v", test.name, readableActions)
+	}
+}

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -381,7 +381,8 @@ func (e *testEnv) Run(m *testing.M) (exitCode int) {
 	for _, setup := range setups {
 		// context passed down to each setup
 		if ctx, err = setup.run(ctx, e.cfg); err != nil {
-			klog.Fatalf("%s failure: %s", setup.role, err)
+			klog.Errorf("%s failure: %s", setup.role, err)
+			break
 		}
 	}
 	e.ctx = ctx


### PR DESCRIPTION
When an error happens during a setup step, instead of calling `klog.Fatal` which causes `os.Exit`, instead do `klog.Error`, `break`, run `defer` function with clean up steps, and `return`.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
I found [this line](https://github.com/kubernetes-sigs/e2e-framework/blob/d19e8b569fb2f94568f8ed74b00227f879798aa0/pkg/env/env.go#L369) to be the problem as to why our KinD cluster deletion was not happening as intended. As soon as an error value is passed during a setup step, `klog.Fatalf(...)` is called:

```go
for _, setup := range setups {
    // context passed down to each setup
    if e.ctx, err = setup.run(e.ctx, e.cfg); err != nil {
        klog.Fatalf("%s failure: %s", setup.role, err)
   }
}
```

According to [klog docs](https://github.com/kubernetes/klog/blob/6ded8085b27eeaf68a13d583a382b125ef1482ee/klog.go#L1606-L1607),

> // Fatal logs to the FATAL, ERROR, WARNING, and INFO logs,
> // prints stack trace(s), then calls OsExit(255).

To reiterate, `klog.Fatal` is stopping all operations and exiting program with `os.Exit`. This is not the behavior I want. What I want to happen is for the setup range loop to stop trying to do the setup steps, and try to get to the function return, `return m.Run()`. However, before returning, I expect the defer block to run next where the finishing steps, like cluster cleanup, happen.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #188 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter the details of what chanages are being introduced:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Gracefully exit when setup fails
```


#### Additional documentation e.g., Usage docs, etc.:

<!--
When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```