### PR TITLE
refactor: expose Levels

### DIFF
--- a/pkg/features/builder.go
+++ b/pkg/features/builder.go
@@ -61,7 +61,7 @@ func (b *FeatureBuilder) Setup(fn Func) *FeatureBuilder {
 // WithSetup adds a new setup step with a pre-defined setup name instead of automating
 // the setup name generation. This can make tests more readable.
 func (b *FeatureBuilder) WithSetup(name string, fn Func) *FeatureBuilder {
-	return b.WithStep(name, types.LevelSetup, fn)
+	return b.WithStep(name, LevelSetup, fn)
 }
 
 // Teardown adds a new teardown step that will be applied after feature test.
@@ -72,16 +72,16 @@ func (b *FeatureBuilder) Teardown(fn Func) *FeatureBuilder {
 // WithTeardown adds a new teardown step with a pre-defined name instead of an
 // auto-generated one
 func (b *FeatureBuilder) WithTeardown(name string, fn Func) *FeatureBuilder {
-	return b.WithStep(name, types.LevelTeardown, fn)
+	return b.WithStep(name, LevelTeardown, fn)
 }
 
 // Assess adds an assessment step to the feature test.
 func (b *FeatureBuilder) Assess(desc string, fn Func) *FeatureBuilder {
-	return b.WithStep(desc, types.LevelAssess, fn)
+	return b.WithStep(desc, LevelAssess, fn)
 }
 
 func (b *FeatureBuilder) AssessWithDescription(name, description string, fn Func) *FeatureBuilder {
-	return b.WithStepDescription(name, description, types.LevelAssess, fn)
+	return b.WithStepDescription(name, description, LevelAssess, fn)
 }
 
 // Feature returns a feature configured by builder.

--- a/pkg/features/feature.go
+++ b/pkg/features/feature.go
@@ -30,6 +30,15 @@ type (
 	Level   = types.Level
 )
 
+const (
+	// LevelSetup when doing the setup phase
+	LevelSetup Level = types.LevelSetup
+	// LevelAssess when doing the assess phase
+	LevelAssess = types.LevelAssess
+	// LevelTeardown when doing the teardown phase
+	LevelTeardown = types.LevelTeardown
+)
+
 type defaultFeature struct {
 	name        string
 	description string

--- a/pkg/features/feature.go
+++ b/pkg/features/feature.go
@@ -32,7 +32,7 @@ type (
 
 const (
 	// LevelSetup when doing the setup phase
-	LevelSetup Level = types.LevelSetup
+	LevelSetup = types.LevelSetup
 	// LevelAssess when doing the assess phase
 	LevelAssess = types.LevelAssess
 	// LevelTeardown when doing the teardown phase


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:
[WithStep](https://github.com/kubernetes-sigs/e2e-framework/blob/15e91144243aab9c611f5706c3e7c48ceb881850/pkg/features/builder.go#L42) accepts a Level as argument, but the actual levels (Setup, Assess, Teardown)  are only declared in an internal package and not publicly exposed. This PR exposes the internal specific Levels.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes-sigs/e2e-framework/issues/288

#### Special notes for your reviewer:
Has to be said that any other Level w.r.t. the 3 intended ones will be ignored, as the code explicitly selects the three steps, so we could also go the other way, remove the public Level and avoid exposing WithStep and WithDescribeStep private, but that would be a breaking change unfortunately.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter the details of what chanages are being introduced:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
```


#### Additional documentation e.g., Usage docs, etc.:

<!--
When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```