### PR TITLE
[env] Don't run next assess when failNow is called

### DIFF
--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -460,17 +460,27 @@ func (e *testEnv) execFeature(ctx context.Context, t *testing.T, featName string
 			if assessName == "" {
 				assessName = fmt.Sprintf("Assessment-%d", i+1)
 			}
+			// shouldFailNow catches whether t.FailNow() is called in the assessment.
+			// If it is, we won't proceed with the next assessment.
+			var shouldFailNow bool
 			newT.Run(assessName, func(internalT *testing.T) {
 				skipped, message := e.requireAssessmentProcessing(assess, i+1)
 				if skipped {
 					internalT.Skipf(message)
 				}
+				// Set shouldFailNow to true before actually running the assessment, because if the assessment
+				// calls t.FailNow(), the function will be abruptly stopped in the middle of `e.executeSteps()`.
+				shouldFailNow = true
 				ctx = e.executeSteps(ctx, internalT, []types.Step{assess})
+				// If we reach this point, it means the assessment did not call t.FailNow().
+				shouldFailNow = false
 			})
-			// Check if the Test assessment under question performed a `t.Fail()` or `t.Failed()` invocation.
-			// We need to track that and stop the next set of assessment in the feature under test from getting
-			// executed
-			if e.cfg.FailFast() && newT.Failed() {
+			// Check if the Test assessment under question performed either 2 things:
+			// - a t.FailNow() invocation
+			// - a `t.Fail()` or `t.Failed()` invocation
+			// In one of those cases, we need to track that and stop the next set of assessment in the feature
+			// under test from getting executed.
+			if shouldFailNow || (e.cfg.FailFast() && newT.Failed()) {
 				failed = true
 				break
 			}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When writing tests, this allows the writer to control whether the test should continue running the next assess when a failure occurs. Basically, they can chose between using `t.FailNow()` or `t.Fail()` depending on if the failure should stop the test or not. It works independently from the `-fail-fast` flag specific to the framework and allows a more granular control on test failures.

#### Which issue(s) this PR fixes:
Fixes #386 

#### Special notes for your reviewer:

I tried to add a new test for this case but couldn't find a way to make it work. Since `failNow` is called, the test fails and I couldn't find a way to expect a test to fail in go :sweat_smile:. Happy to add one if someone has an idea on how to do it though.

##### Code to reproduce

You can use the following code to illustrate what I'm trying to solve
```go
package envfuncs_test

import (
	"context"
	"os"
	"testing"

	"sigs.k8s.io/e2e-framework/pkg/env"
	"sigs.k8s.io/e2e-framework/pkg/envconf"
	"sigs.k8s.io/e2e-framework/pkg/features"
)

var testenv env.Environment

func TestMain(m *testing.M) {
	testenv = env.New()
	os.Exit(testenv.Run(m))
}

func TestFailNow(t *testing.T) {
	feat1 := features.New("fail now").
		Assess("Assess 1", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
			t.Log("Assess 1 (should be printed)")
			t.FailNow()
			return ctx
		}).
		Assess("Assess 2", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
			t.Log("Assess 2 (should NOT be printed)")
			return ctx
		}).
		Feature()

	feat2 := features.New("succeed").
		Assess("Assess 1", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
			t.Log("Assess 1 (should be printed)")
			return ctx
		}).
		Assess("Assess 2", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
			t.Log("Assess 2 (should be printed)")
			return ctx
		}).
		Feature()

	testenv.Test(t, feat1, feat2)
}

func TestFail(t *testing.T) {
	feat := features.New("fail (not now)").
		Assess("Assess 1", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
			t.Log("Assess 1 (should be printed)")
			t.Fail()
			return ctx
		}).
		Assess("Assess 2", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
			t.Log("Assess 2 (should be printed)")
			return ctx
		}).
		Feature()

	testenv.Test(t, feat)
}
```

- Before the changes, here is the output:
```
❯ go test ./pkg/envfuncs -test.v
=== RUN   TestFailNow
=== RUN   TestFailNow/fail_now
=== RUN   TestFailNow/fail_now/Assess_1
    ns_funcs_test.go:39: Assess 1 (should be printed)
=== RUN   TestFailNow/fail_now/Assess_2
    ns_funcs_test.go:44: Assess 2 (should NOT be printed)
=== RUN   TestFailNow/succeed
=== RUN   TestFailNow/succeed/Assess_1
    ns_funcs_test.go:51: Assess 1 (should be printed)
=== RUN   TestFailNow/succeed/Assess_2
    ns_funcs_test.go:55: Assess 2 (should be printed)
--- FAIL: TestFailNow (0.00s)
    --- FAIL: TestFailNow/fail_now (0.00s)
        --- FAIL: TestFailNow/fail_now/Assess_1 (0.00s)
        --- PASS: TestFailNow/fail_now/Assess_2 (0.00s)
    --- PASS: TestFailNow/succeed (0.00s)
        --- PASS: TestFailNow/succeed/Assess_1 (0.00s)
        --- PASS: TestFailNow/succeed/Assess_2 (0.00s)
=== RUN   TestFail
=== RUN   TestFail/fail_(not_now)
=== RUN   TestFail/fail_(not_now)/Assess_1
    ns_funcs_test.go:66: Assess 1 (should be printed)
=== RUN   TestFail/fail_(not_now)/Assess_2
    ns_funcs_test.go:71: Assess 2 (should be printed)
--- FAIL: TestFail (0.00s)
    --- FAIL: TestFail/fail_(not_now) (0.00s)
        --- FAIL: TestFail/fail_(not_now)/Assess_1 (0.00s)
        --- PASS: TestFail/fail_(not_now)/Assess_2 (0.00s)
FAIL
FAIL	sigs.k8s.io/e2e-framework/pkg/envfuncs	0.008s
FAIL

```
- Now it is:
```
❯ go test ./pkg/envfuncs -test.v
=== RUN   TestFailNow
=== RUN   TestFailNow/fail_now
=== RUN   TestFailNow/fail_now/Assess_1
    ns_funcs_test.go:153: Assess 1 (should be printed)
=== RUN   TestFailNow/succeed
=== RUN   TestFailNow/succeed/Assess_1
    ns_funcs_test.go:165: Assess 1 (should be printed)
=== RUN   TestFailNow/succeed/Assess_2
    ns_funcs_test.go:169: Assess 2 (should be printed)
--- FAIL: TestFailNow (0.00s)
    --- FAIL: TestFailNow/fail_now (0.00s)
        --- FAIL: TestFailNow/fail_now/Assess_1 (0.00s)
    --- PASS: TestFailNow/succeed (0.00s)
        --- PASS: TestFailNow/succeed/Assess_1 (0.00s)
        --- PASS: TestFailNow/succeed/Assess_2 (0.00s)
=== RUN   TestFail
=== RUN   TestFail/fail_(not_now)
=== RUN   TestFail/fail_(not_now)/Assess_1
    ns_funcs_test.go:180: Assess 1 (should be printed)
=== RUN   TestFail/fail_(not_now)/Assess_2
    ns_funcs_test.go:185: Assess 2 (should be printed)
--- FAIL: TestFail (0.00s)
    --- FAIL: TestFail/fail_(not_now) (0.00s)
        --- FAIL: TestFail/fail_(not_now)/Assess_1 (0.00s)
        --- PASS: TestFail/fail_(not_now)/Assess_2 (0.00s)
FAIL
FAIL	sigs.k8s.io/e2e-framework/pkg/envfuncs	0.013s
FAIL
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter the details of what chanages are being introduced:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Stopped running the following assess if FailNow() was called during a test
```


#### Additional documentation e.g., Usage docs, etc.:

<!--
When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```