### PR TITLE
fix(support): propagate kind image options to CLI

### DIFF
--- a/support/kind/kind.go
+++ b/support/kind/kind.go
@@ -150,9 +150,6 @@ func (k *Cluster) CreateWithConfig(ctx context.Context, kindConfigFile string) (
 	if kindConfigFile != "" {
 		args = append(args, "--config", kindConfigFile)
 	}
-	if k.image != "" {
-		args = append(args, "--image", k.image)
-	}
 	return k.Create(ctx, args...)
 }
 
@@ -165,6 +162,10 @@ func (k *Cluster) Create(ctx context.Context, args ...string) (string, error) {
 	if _, ok := k.clusterExists(k.name); ok {
 		log.V(4).Info("Skipping Kind Cluster.Create: cluster already created: ", k.name)
 		return k.getKubeconfig()
+	}
+
+	if k.image != "" {
+		args = append(args, "--image", k.image)
 	}
 
 	command := fmt.Sprintf(`%s create cluster --name %s`, k.path, k.name)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The current support E2EClusterProvider API for creating Kind clusters is confusing/misleading.
Say, I want to create a Kind cluster with a custom image:

```go
import "sigs.k8s.io/e2e-framework/support/kind"

p := kind.NewProvider().WithOpts(kind.WithImage("..."))
```

When used with `envfuncs.CreateCluster` I would expect this to work, but when you dig down to it, the image name is never passed down to the CLI arguments:
https://github.com/kubernetes-sigs/e2e-framework/blob/fdcf509f96c96f0055b03f026ea44c62df82c753/support/kind/kind.go#L170

Confusingly, the other variant `kind.CreateWithConfig` does https://github.com/kubernetes-sigs/e2e-framework/blob/fdcf509f96c96f0055b03f026ea44c62df82c753/support/kind/kind.go#L153

The behavior should be the same for both.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional documentation e.g., Usage docs, etc.: