### PR TITLE
initialize k8s client access appropriately when a cluster exists

### DIFF
--- a/support/kind/kind.go
+++ b/support/kind/kind.go
@@ -158,7 +158,11 @@ func (k *Cluster) Create(ctx context.Context, args ...string) (string, error) {
 
 	if _, ok := k.clusterExists(k.name); ok {
 		log.V(4).Info("Skipping Kind Cluster.Create: cluster already created: ", k.name)
-		return k.getKubeconfig()
+		kConfig, err := k.getKubeconfig()
+		if err != nil {
+			return "", err
+		}
+		return kConfig, k.initKubernetesAccessClients()
 	}
 
 	if k.image != "" {

--- a/support/kwok/kwok.go
+++ b/support/kwok/kwok.go
@@ -129,7 +129,11 @@ func (k *Cluster) Create(ctx context.Context, args ...string) (string, error) {
 	}
 	if _, ok := k.clusterExists(k.name); ok {
 		klog.V(4).Info("Skipping Kwok Cluster creation. Cluster already created ", k.name)
-		return k.getKubeconfig()
+		kConfig, err := k.getKubeconfig()
+		if err != nil {
+			return "", err
+		}
+		return kConfig, k.initKubernetesAccessClients()
 	}
 
 	command := fmt.Sprintf(`%s create cluster --name %s --wait %s`, k.path, k.name, k.waitDuration.String())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

ssia.
Currently, when a cluster already exists, `initKubernetesAccessClients` won't be run.
`initKubernetesAccessClients` is mandatory to be run to make `*cluster` return `KubernetesRestConfig`, and consequently now `KubernetesRestConfig` always results in `nil` in such case. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter the details of what chanages are being introduced:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix a bug which both kwok and kind providers don't work expectedly when a cluster already exists.
```


#### Additional documentation e.g., Usage docs, etc.:

<!--
When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```