### PR TITLE
Mark E2E plumbing as test helpers

### DIFF
--- a/pkg/env/action.go
+++ b/pkg/env/action.go
@@ -72,6 +72,7 @@ type action struct {
 
 // runWithT will run the action and inject *testing.T into the callback function.
 func (a *action) runWithT(ctx context.Context, cfg *envconf.Config, t *testing.T) (context.Context, error) {
+	t.Helper()
 	switch a.role {
 	case roleBeforeTest, roleAfterTest:
 		if cfg.DryRunMode() {
@@ -98,6 +99,7 @@ func (a *action) runWithT(ctx context.Context, cfg *envconf.Config, t *testing.T
 
 // runWithFeature will run the action and inject a FeatureInfo object into the callback function.
 func (a *action) runWithFeature(ctx context.Context, cfg *envconf.Config, t *testing.T, fi types.Feature) (context.Context, error) {
+	t.Helper()
 	switch a.role {
 	case roleBeforeFeature, roleAfterFeature:
 		if cfg.DryRunMode() {

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -207,6 +207,7 @@ func (e *testEnv) panicOnMissingContext() {
 // processTestActions is used to run a series of test action that were configured as
 // BeforeEachTest or AfterEachTest
 func (e *testEnv) processTestActions(ctx context.Context, t *testing.T, actions []action) context.Context {
+	t.Helper()
 	var err error
 	out := ctx
 	for _, action := range actions {
@@ -222,6 +223,7 @@ func (e *testEnv) processTestActions(ctx context.Context, t *testing.T, actions 
 // workflow of orchestrating the feature execution be running the action configured by BeforeEachFeature /
 // AfterEachFeature.
 func (e *testEnv) processTestFeature(ctx context.Context, t *testing.T, featureName string, feature types.Feature) context.Context {
+	t.Helper()
 	skipped, message := e.requireFeatureProcessing(feature)
 	if skipped {
 		t.Skipf(message)
@@ -239,6 +241,7 @@ func (e *testEnv) processTestFeature(ctx context.Context, t *testing.T, featureN
 // processFeatureActions is used to run a series of feature action that were configured as
 // BeforeEachFeature or AfterEachFeature
 func (e *testEnv) processFeatureActions(ctx context.Context, t *testing.T, feature types.Feature, actions []action) context.Context {
+	t.Helper()
 	var err error
 	out := ctx
 	for _, action := range actions {
@@ -257,6 +260,7 @@ func (e *testEnv) processFeatureActions(ctx context.Context, t *testing.T, featu
 // In case if the parallel run of test features are enabled, this function will invoke the processTestFeature
 // as a go-routine to get them to run in parallel
 func (e *testEnv) processTests(ctx context.Context, t *testing.T, enableParallelRun bool, testFeatures ...types.Feature) context.Context {
+	t.Helper()
 	dedicatedTestEnv := newChildTestEnv(e)
 	if dedicatedTestEnv.cfg.DryRunMode() {
 		klog.V(2).Info("e2e-framework is being run in dry-run mode. This will skip all the before/after step functions configured around your test assessments and features")
@@ -327,6 +331,7 @@ func (e *testEnv) processTests(ctx context.Context, t *testing.T, enableParallel
 // are executed in parallel to avoid duplication of action that might happen
 // in BeforeTest and AfterTest actions
 func (e *testEnv) TestInParallel(t *testing.T, testFeatures ...types.Feature) context.Context {
+	t.Helper()
 	return e.processTests(e.ctx, t, true, testFeatures...)
 }
 
@@ -343,6 +348,7 @@ func (e *testEnv) TestInParallel(t *testing.T, testFeatures ...types.Feature) co
 // BeforeTest and AfterTest operations are executed before and after
 // the feature is tested respectively.
 func (e *testEnv) Test(t *testing.T, testFeatures ...types.Feature) context.Context {
+	t.Helper()
 	return e.processTests(e.ctx, t, false, testFeatures...)
 }
 
@@ -455,6 +461,7 @@ func (e *testEnv) getFinishActions() []action {
 }
 
 func (e *testEnv) executeSteps(ctx context.Context, t *testing.T, steps []types.Step) context.Context {
+	t.Helper()
 	if e.cfg.DryRunMode() {
 		return ctx
 	}
@@ -465,8 +472,11 @@ func (e *testEnv) executeSteps(ctx context.Context, t *testing.T, steps []types.
 }
 
 func (e *testEnv) execFeature(ctx context.Context, t *testing.T, featName string, f types.Feature) context.Context {
+	t.Helper()
 	// feature-level subtest
 	t.Run(featName, func(newT *testing.T) {
+		newT.Helper()
+
 		if fDescription, ok := f.(types.DescribableFeature); ok && fDescription.Description() != "" {
 			t.Logf("Processing Feature: %s", fDescription.Description())
 		}
@@ -491,6 +501,7 @@ func (e *testEnv) execFeature(ctx context.Context, t *testing.T, featName string
 			// If it is, we won't proceed with the next assessment.
 			var shouldFailNow bool
 			newT.Run(assessName, func(internalT *testing.T) {
+				internalT.Helper()
 				skipped, message := e.requireAssessmentProcessing(assess, i+1)
 				if skipped {
 					internalT.Skipf(message)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

In Crossplane we try to use reusable step functions in our E2E tests, so they end up looking like this:

```go
func TestExample(t *testing.T) {
	environment.Test(t,
		features.New(t.Name()).
			WithSetup("ExampleSetup", funcs.SomeSetupFn()).
			Assess("ExampleAssess", funcs.SomeAssessFn()).
			WithTeardown("ExampleTeardown", funcs.SomeTearDownFn()).
			Feature(),
	)
}
```

Since step functions are passed `*testing.T` we'll often call `t.Error`, `t.Log`, etc from our step functions. These testing calls include the call point (i.e. filename and line number) in their output. Without using `t.Helper()` the call point will be the file where the step function is defined (e.g. `features.go`) rather than the calling test.

We want to mark our step functions as test helpers using `t.Helper` so that the calling test is included in the output. For this to work we need to mark all the intermediary plumbing functions and methods in e2e-framework as helpers too.

#### Which issue(s) this PR fixes:

I didn't raise an issue tracking this.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Internal machinery used to call step functions is now marked as test helpers. This means you can mark your step functions as a test helper using `t.Helper()`, and test logs will be include the filename and line number of `environment.Test()` call.
```


#### Additional documentation e.g., Usage docs, etc.:

<!--
When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```