### PR TITLE
execute test suite only if the setup was successful

### DIFF
--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -382,18 +382,13 @@ func (e *testEnv) Run(m *testing.M) (exitCode int) {
 		// context passed down to each setup
 		if ctx, err = setup.run(ctx, e.cfg); err != nil {
 			klog.Errorf("%s failure: %s", setup.role, err)
-			exitCode = 1
-			break
+			return 1
 		}
 	}
 	e.ctx = ctx
 
-	// Execute the test suite (if the setup was successful)
-	if err == nil {
-		exitCode = m.Run()
-	}
-
-	return exitCode
+	// Execute the test suite
+	return m.Run()
 }
 
 func (e *testEnv) getActionsByRole(r actionRole) []action {

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -382,13 +382,18 @@ func (e *testEnv) Run(m *testing.M) (exitCode int) {
 		// context passed down to each setup
 		if ctx, err = setup.run(ctx, e.cfg); err != nil {
 			klog.Errorf("%s failure: %s", setup.role, err)
+			exitCode = 1
 			break
 		}
 	}
 	e.ctx = ctx
 
-	// Execute the test suite
-	return m.Run()
+	// Execute the test suite (if the setup was successful)
+	if err == nil {
+		exitCode = m.Run()
+	}
+
+	return exitCode
 }
 
 func (e *testEnv) getActionsByRole(r actionRole) []action {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Since the last changes ( #362) in the error handling of the setup functions, the test suite is also executed if the setup has failed. This can cause the tests to run to timeout because the expected prerequisites are not met. This PR introduces a check to ensure that the test suite is only executed if the setup was successful, otherwise the function returns with exit code 1 and the finish functions are gracefully executed.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #423

#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?
<!-- 
If no, just write "NONE" in the release-note block below.
If yes, please enter the details of what chanages are being introduced:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```docs
The test suite is only executed if the setup was successful.
```

#### Additional documentation e.g., Usage docs, etc.:

<!--
When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```