### PR TITLE
Fix value propagation in context for test actions

### DIFF
--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -194,7 +194,7 @@ func (e *testEnv) processTestActions(ctx context.Context, t *testing.T, actions 
 	var err error
 	out := ctx
 	for _, action := range actions {
-		out, err = action.runWithT(ctx, e.cfg, t)
+		out, err = action.runWithT(out, e.cfg, t)
 		if err != nil {
 			t.Fatalf("%s failure: %s", action.role, err)
 		}

--- a/pkg/env/env_test.go
+++ b/pkg/env/env_test.go
@@ -324,10 +324,12 @@ func TestEnv_Test(t *testing.T) {
 			name: "context value propagation with with multiple features, before, during, and after test",
 			ctx:  context.TODO(),
 			expected: []string{
-				"before-each-test",
+				"before-each-test-1",
+				"before-each-test-2",
 				"test-feat-1",
 				"test-feat-2",
-				"after-each-test",
+				"after-each-test-1",
+				"after-each-test-2",
 			},
 			setup: func(ctx context.Context, t *testing.T) []string {
 				env, err := NewWithContext(context.WithValue(ctx, &ctxTestKeyString{}, []string{}), envconf.New())
@@ -340,7 +342,16 @@ func TestEnv_Test(t *testing.T) {
 					if !ok {
 						t.Fatal("context value was not []string")
 					}
-					val = append(val, "before-each-test")
+					val = append(val, "before-each-test-1")
+					return context.WithValue(ctx, &ctxTestKeyString{}, val), nil
+				})
+				env.BeforeEachTest(func(ctx context.Context, _ *envconf.Config, t *testing.T) (context.Context, error) {
+					// update before test
+					val, ok := ctx.Value(&ctxTestKeyString{}).([]string)
+					if !ok {
+						t.Fatal("context value was not []string")
+					}
+					val = append(val, "before-each-test-2")
 					return context.WithValue(ctx, &ctxTestKeyString{}, val), nil
 				})
 				env.AfterEachTest(func(ctx context.Context, _ *envconf.Config, t *testing.T) (context.Context, error) {
@@ -349,7 +360,16 @@ func TestEnv_Test(t *testing.T) {
 					if !ok {
 						t.Fatal("context value was not []string")
 					}
-					val = append(val, "after-each-test")
+					val = append(val, "after-each-test-1")
+					return context.WithValue(ctx, &ctxTestKeyString{}, val), nil
+				})
+				env.AfterEachTest(func(ctx context.Context, _ *envconf.Config, t *testing.T) (context.Context, error) {
+					// update after the test
+					val, ok := ctx.Value(&ctxTestKeyString{}).([]string)
+					if !ok {
+						t.Fatal("context value was not []string")
+					}
+					val = append(val, "after-each-test-2")
 					return context.WithValue(ctx, &ctxTestKeyString{}, val), nil
 				})
 				f1 := features.New("test-feat").Assess("assess", func(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
In case multiple `BeforeEachTest` or `AfterEachTest` actions are used, the values of the context created by the first registered action are not propagated further.

#### Which issue(s) this PR fixes:
N/A

#### Special notes for your reviewer:
If the modified unit test would be run without the bug fix the output would be:
```
--- FAIL: TestEnv_Test (0.00s)
    --- FAIL: TestEnv_Test/context_value_propagation_with_with_multiple_features,_before,_during,_and_after_test (0.00s)
        env_test.go:643: Expected:
            [before-each-test-1 before-each-test-2 test-feat-1 test-feat-2 after-each-test-1 after-each-test-2] but got result:
            [before-each-test-2 test-feat-1 test-feat-2 after-each-test-2]
FAIL
FAIL    sigs.k8s.io/e2e-framework/pkg/env       8.020s
FAIL
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter the details of what chanages are being introduced:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
```