### PR TITLE
add teardown when TestExecPod finished

### DIFF
--- a/examples/multi_cluster/deployment_test.go
+++ b/examples/multi_cluster/deployment_test.go
@@ -37,7 +37,7 @@ import (
 
 var curDir, _ = os.Getwd()
 
-func checkPodStatus(t *testing.T, kubeConfig string, clusterName string) {
+func checkDeploymentStatus(t *testing.T, kubeConfig string, clusterName string) {
 	t.Helper()
 	client, err := klient.NewWithKubeConfigFile(kubeConfig)
 	if err != nil {
@@ -79,7 +79,7 @@ func TestScenarioOne(t *testing.T) {
 			if !ok {
 				t.Fatalf("Failed to extract kind cluster %s from context", clusterNames[0])
 			}
-			checkPodStatus(t, cluster.GetKubeconfig(), clusterNames[0])
+			checkDeploymentStatus(t, cluster.GetKubeconfig(), clusterNames[0])
 			return ctx
 		}).
 		Assess(fmt.Sprintf("Deployment is running successfully - %s", clusterNames[1]), func(ctx context.Context, t *testing.T, config *envconf.Config) context.Context {
@@ -87,7 +87,7 @@ func TestScenarioOne(t *testing.T) {
 			if !ok {
 				t.Fatalf("Failed to extract kind cluster %s from context", clusterNames[1])
 			}
-			checkPodStatus(t, cluster.GetKubeconfig(), clusterNames[1])
+			checkDeploymentStatus(t, cluster.GetKubeconfig(), clusterNames[1])
 			return ctx
 		}).
 		Feature()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
- add teardown when TestExecPod finished
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter the details of what chanages are being introduced:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```


#### Additional documentation e.g., Usage docs, etc.:

<!--
When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```