### PR TITLE
feat: add vcluster e2e cluster provider

### DIFF
--- a/examples/vcluster/vcluster_with_config/main_test.go
+++ b/examples/vcluster/vcluster_with_config/main_test.go
@@ -1,9 +1,12 @@
 /*
 Copyright 2024 The Kubernetes Authors.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/examples/vcluster/vcluster_with_config/main_test.go
+++ b/examples/vcluster/vcluster_with_config/main_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vcluster
+
+import (
+	"context"
+	"log"
+	"os"
+	"testing"
+
+	"sigs.k8s.io/e2e-framework/klient/conf"
+	"sigs.k8s.io/e2e-framework/pkg/env"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/envfuncs"
+	"sigs.k8s.io/e2e-framework/support"
+	"sigs.k8s.io/e2e-framework/support/kind"
+	"sigs.k8s.io/e2e-framework/third_party/vcluster"
+)
+
+var testenv env.Environment
+
+func TestMain(m *testing.M) {
+	opts := []support.ClusterOpts{}
+	// vcluster requires a "host" cluster to install into, so we should resolve one
+	if os.Getenv("REAL_CLUSTER") == "true" {
+		cfg := conf.ResolveKubeConfigFile()
+		opts = append(opts, vcluster.WithHostKubeConfig(cfg))
+	} else {
+		// create a kind cluster to use as the vcluster "host"
+		cfg, err := kind.NewProvider().WithName("kind-vc-host").Create(context.Background())
+		if err != nil {
+			log.Fatal(err)
+		}
+		opts = append(opts, vcluster.WithHostKubeConfig(cfg))
+	}
+
+	testenv, _ = env.NewFromFlags()
+	vclusterName := envconf.RandomName("vcluster-with-config", 16)
+	namespace := envconf.RandomName("vcluster-ns", 16)
+	opts = append(opts, vcluster.WithNamespace(namespace))
+	testenv.Setup(
+		envfuncs.CreateNamespace(namespace),
+		envfuncs.CreateClusterWithConfig(vcluster.NewProvider(), vclusterName, "values.yaml", opts...),
+	)
+
+	testenv.Finish(
+		envfuncs.DestroyCluster(vclusterName),
+		envfuncs.DeleteNamespace(namespace),
+	)
+
+	if os.Getenv("REAL_CLUSTER") != "true" {
+		// cleanup the vcluster "host"-kind-cluster
+		testenv.Finish(
+			func(ctx context.Context, c *envconf.Config) (context.Context, error) {
+				if err := kind.NewProvider().WithName("kind-vc-host").Destroy(ctx); err != nil {
+					return ctx, err
+				}
+				return ctx, nil
+			},
+		)
+	}
+
+	os.Exit(testenv.Run(m))
+}

--- a/examples/vcluster/vcluster_with_config/values.yaml
+++ b/examples/vcluster/vcluster_with_config/values.yaml
@@ -1,0 +1,1 @@
+# TODO: add vcluster configs

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	k8s.io/component-base v0.31.2
 	k8s.io/klog/v2 v2.130.1
 	sigs.k8s.io/controller-runtime v0.19.1
+	sigs.k8s.io/yaml v1.4.0
 )
 
 require (
@@ -61,5 +62,4 @@ require (
 	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
-	sigs.k8s.io/yaml v1.4.0 // indirect
 )

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -226,7 +226,7 @@ func (e *testEnv) processTestFeature(ctx context.Context, t *testing.T, featureN
 	t.Helper()
 	skipped, message := e.requireFeatureProcessing(feature)
 	if skipped {
-		t.Skipf(message)
+		t.Skip(message)
 	}
 	// execute beforeEachFeature actions
 	ctx = e.processFeatureActions(ctx, t, feature, e.getBeforeFeatureActions())
@@ -510,7 +510,7 @@ func (e *testEnv) execFeature(ctx context.Context, t *testing.T, featName string
 				internalT.Helper()
 				skipped, message := e.requireAssessmentProcessing(assess, i+1)
 				if skipped {
-					internalT.Skipf(message)
+					internalT.Skip(message)
 				}
 				// Set shouldFailNow to true before actually running the assessment, because if the assessment
 				// calls t.FailNow(), the function will be abruptly stopped in the middle of `e.executeSteps()`.

--- a/third_party/flux/flux_setup.go
+++ b/third_party/flux/flux_setup.go
@@ -18,6 +18,7 @@ package flux
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"sigs.k8s.io/e2e-framework/pkg/env"
@@ -44,7 +45,7 @@ func InstallFlux(opts ...Option) env.Func {
 func CreateGitRepo(gitRepoName, gitRepoURL string, opts ...Option) env.Func {
 	return func(ctx context.Context, c *envconf.Config) (context.Context, error) {
 		if manager == nil {
-			return ctx, fmt.Errorf(NoFluxInstallationFoundMsg)
+			return ctx, errors.New(NoFluxInstallationFoundMsg)
 		}
 		err := manager.createSource(Git, gitRepoName, gitRepoURL, opts...)
 		if err != nil {
@@ -58,7 +59,7 @@ func CreateGitRepo(gitRepoName, gitRepoURL string, opts ...Option) env.Func {
 func CreateHelmRepository(name, url string, opts ...Option) env.Func {
 	return func(ctx context.Context, c *envconf.Config) (context.Context, error) {
 		if manager == nil {
-			return ctx, fmt.Errorf(NoFluxInstallationFoundMsg)
+			return ctx, errors.New(NoFluxInstallationFoundMsg)
 		}
 		err := manager.createSource(Helm, name, url, opts...)
 		if err != nil {
@@ -72,7 +73,7 @@ func CreateHelmRepository(name, url string, opts ...Option) env.Func {
 func CreateKustomization(kustomizationName, sourceRef string, opts ...Option) env.Func {
 	return func(ctx context.Context, c *envconf.Config) (context.Context, error) {
 		if manager == nil {
-			return ctx, fmt.Errorf(NoFluxInstallationFoundMsg)
+			return ctx, errors.New(NoFluxInstallationFoundMsg)
 		}
 		err := manager.createKustomization(kustomizationName, sourceRef, opts...)
 		if err != nil {
@@ -87,7 +88,7 @@ func CreateKustomization(kustomizationName, sourceRef string, opts ...Option) en
 func CreateHelmRelease(name, source, chart string, opts ...Option) env.Func {
 	return func(ctx context.Context, c *envconf.Config) (context.Context, error) {
 		if manager == nil {
-			return ctx, fmt.Errorf(NoFluxInstallationFoundMsg)
+			return ctx, errors.New(NoFluxInstallationFoundMsg)
 		}
 		err := manager.createHelmRelease(name, source, chart, opts...)
 		if err != nil {
@@ -101,7 +102,7 @@ func CreateHelmRelease(name, source, chart string, opts ...Option) env.Func {
 func UninstallFlux(opts ...Option) env.Func {
 	return func(ctx context.Context, c *envconf.Config) (context.Context, error) {
 		if manager == nil {
-			return ctx, fmt.Errorf(NoFluxInstallationFoundMsg)
+			return ctx, errors.New(NoFluxInstallationFoundMsg)
 		}
 		err := manager.uninstallFlux(opts...)
 		if err != nil {
@@ -115,7 +116,7 @@ func UninstallFlux(opts ...Option) env.Func {
 func DeleteKustomization(kustomizationName string, opts ...Option) env.Func {
 	return func(ctx context.Context, c *envconf.Config) (context.Context, error) {
 		if manager == nil {
-			return ctx, fmt.Errorf(NoFluxInstallationFoundMsg)
+			return ctx, errors.New(NoFluxInstallationFoundMsg)
 		}
 		err := manager.deleteKustomization(kustomizationName, opts...)
 		if err != nil {
@@ -129,7 +130,7 @@ func DeleteKustomization(kustomizationName string, opts ...Option) env.Func {
 func DeleteHelmRelease(name string, opts ...Option) env.Func {
 	return func(ctx context.Context, c *envconf.Config) (context.Context, error) {
 		if manager == nil {
-			return ctx, fmt.Errorf(NoFluxInstallationFoundMsg)
+			return ctx, errors.New(NoFluxInstallationFoundMsg)
 		}
 		err := manager.deleteHelmRelease(name, opts...)
 		if err != nil {
@@ -143,7 +144,7 @@ func DeleteHelmRelease(name string, opts ...Option) env.Func {
 func DeleteGitRepo(gitRepoName string, opts ...Option) env.Func {
 	return func(ctx context.Context, c *envconf.Config) (context.Context, error) {
 		if manager == nil {
-			return ctx, fmt.Errorf(NoFluxInstallationFoundMsg)
+			return ctx, errors.New(NoFluxInstallationFoundMsg)
 		}
 		err := manager.deleteSource(Git, gitRepoName, opts...)
 		if err != nil {
@@ -157,7 +158,7 @@ func DeleteGitRepo(gitRepoName string, opts ...Option) env.Func {
 func DeleteHelmRepo(name string, opts ...Option) env.Func {
 	return func(ctx context.Context, c *envconf.Config) (context.Context, error) {
 		if manager == nil {
-			return ctx, fmt.Errorf(NoFluxInstallationFoundMsg)
+			return ctx, errors.New(NoFluxInstallationFoundMsg)
 		}
 		err := manager.deleteSource(Helm, name, opts...)
 		if err != nil {

--- a/third_party/helm/helm.go
+++ b/third_party/helm/helm.go
@@ -18,6 +18,7 @@ package helm
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -237,7 +238,7 @@ func (m *Manager) run(opts *Opts) (err error) {
 	}
 	log.V(4).InfoS("Determining if helm binary is available or not", "executable", m.path)
 	if m.e.Prog().Avail(m.path) == "" {
-		err = fmt.Errorf(missingHelm)
+		err = errors.New(missingHelm)
 		return
 	}
 	command, err := m.getCommand(opts)

--- a/third_party/ko/ko.go
+++ b/third_party/ko/ko.go
@@ -19,6 +19,7 @@ package ko
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -159,7 +160,7 @@ func (m *Manager) GetLocalImage(ctx context.Context, packagePath string) (string
 func (m *Manager) run(opts *Opts) (out string, err error) {
 	log.V(4).InfoS("Determining if ko binary is available or not", "executable", m.path)
 	if m.e.Prog().Avail(m.path) == "" {
-		return "", fmt.Errorf(missingKo)
+		return "", errors.New(missingKo)
 	}
 
 	envs := m.getEnvs(opts)

--- a/third_party/kubetest2/pkg/tester/e2e-tester_test.go
+++ b/third_party/kubetest2/pkg/tester/e2e-tester_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package tester
 
 import (
-	"github.com/octago/sflags/gen/gpflag"
 	"testing"
+
+	"github.com/octago/sflags/gen/gpflag"
 )
 
 func TestBuildFlags(t *testing.T) {

--- a/third_party/vcluster/vcluster.go
+++ b/third_party/vcluster/vcluster.go
@@ -1,9 +1,12 @@
 /*
 Copyright 2024 The Kubernetes Authors.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/third_party/vcluster/vcluster.go
+++ b/third_party/vcluster/vcluster.go
@@ -40,7 +40,7 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-var vclusterVersion = "v0.20.0"
+var vclusterVersion = "v0.21.0"
 
 type Cluster struct {
 	path            string
@@ -273,7 +273,7 @@ func (c *Cluster) KubernetesRestConfig() *rest.Config {
 // helpers to implement support.E2EClusterProvider
 func (c *Cluster) findOrInstallVcluster() error {
 	version := c.version
-	if c.version != "" {
+	if c.version == "" {
 		version = vclusterVersion
 	}
 	path, err := utils.FindOrInstallGoBasedProvider(c.path, "vcluster", "github.com/loft-sh/vcluster/cmd/vcluster", version)

--- a/third_party/vcluster/vcluster.go
+++ b/third_party/vcluster/vcluster.go
@@ -40,7 +40,10 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-var vclusterVersion = "v0.21.0"
+const (
+	vclusterVersion = "v0.20.0"
+	vclusterPath    = "vclusterctl"
+)
 
 type Cluster struct {
 	path            string
@@ -68,7 +71,7 @@ func WithPath(path string) support.ClusterOpts {
 	return func(c support.E2EClusterProvider) {
 		v, ok := c.(*Cluster)
 		if ok {
-			v.path = path
+			v.WithPath(path)
 		}
 	}
 }
@@ -124,7 +127,7 @@ func (c *Cluster) WithOpts(opts ...support.ClusterOpts) support.E2EClusterProvid
 
 func (c *Cluster) SetDefaults() support.E2EClusterProvider {
 	if c.path == "" {
-		c.path = "vcluster"
+		c.path = vclusterPath
 	}
 	return c
 }
@@ -276,7 +279,7 @@ func (c *Cluster) findOrInstallVcluster() error {
 	if c.version == "" {
 		version = vclusterVersion
 	}
-	path, err := utils.FindOrInstallGoBasedProvider(c.path, "vcluster", "github.com/loft-sh/vcluster/cmd/vcluster", version)
+	path, err := utils.FindOrInstallGoBasedProvider(c.path, vclusterPath, "github.com/loft-sh/vcluster/cmd/vclusterctl", version)
 	if path != "" {
 		c.path = path
 	}

--- a/third_party/vcluster/vcluster.go
+++ b/third_party/vcluster/vcluster.go
@@ -1,0 +1,324 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vcluster
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/vladimirvivien/gexe"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+	log "k8s.io/klog/v2"
+	"sigs.k8s.io/e2e-framework/klient"
+	"sigs.k8s.io/e2e-framework/klient/conf"
+	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
+	"sigs.k8s.io/e2e-framework/klient/wait"
+	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
+	"sigs.k8s.io/e2e-framework/support"
+	"sigs.k8s.io/e2e-framework/support/utils"
+	"sigs.k8s.io/yaml"
+)
+
+var vclusterVersion = "v0.20.0"
+
+type Cluster struct {
+	path            string
+	name            string
+	kubecfgFile     string // kubeconfig file for the vcluster
+	version         string
+	namespace       string // namespace to create the vcluster in
+	hostKubeCfg     string // kubeconfig file for the host cluster
+	hostKubeContext string // kubeconfig context for the host cluster
+	rc              *rest.Config
+}
+
+// Enforce Type check always to avoid future breaks
+var _ support.E2EClusterProvider = &Cluster{}
+
+func NewCluster(name string) *Cluster {
+	return &Cluster{name: name}
+}
+
+func NewProvider() support.E2EClusterProvider {
+	return &Cluster{}
+}
+
+func WithPath(path string) support.ClusterOpts {
+	return func(c support.E2EClusterProvider) {
+		v, ok := c.(*Cluster)
+		if ok {
+			v.path = path
+		}
+	}
+}
+
+func WithNamespace(ns string) support.ClusterOpts {
+	return func(c support.E2EClusterProvider) {
+		v, ok := c.(*Cluster)
+		if ok {
+			v.namespace = ns
+		}
+	}
+}
+
+func WithHostKubeConfig(kubeconfig string) support.ClusterOpts {
+	return func(c support.E2EClusterProvider) {
+		v, ok := c.(*Cluster)
+		if ok {
+			v.hostKubeCfg = kubeconfig
+		}
+	}
+}
+
+func WithHostKubeContext(context string) support.ClusterOpts {
+	return func(c support.E2EClusterProvider) {
+		v, ok := c.(*Cluster)
+		if ok {
+			v.hostKubeContext = context
+		}
+	}
+}
+
+func (c *Cluster) WithName(name string) support.E2EClusterProvider {
+	c.name = name
+	return c
+}
+
+func (c *Cluster) WithVersion(version string) support.E2EClusterProvider {
+	c.version = version
+	return c
+}
+
+func (c *Cluster) WithPath(path string) support.E2EClusterProvider {
+	c.path = path
+	return c
+}
+func (c *Cluster) WithOpts(opts ...support.ClusterOpts) support.E2EClusterProvider {
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+func (c *Cluster) SetDefaults() support.E2EClusterProvider {
+	if c.path == "" {
+		c.path = "vcluster"
+	}
+	return c
+}
+func (c *Cluster) Create(ctx context.Context, args ...string) (string, error) {
+	log.V(4).Info("Creating vcluster ", c.name)
+	if err := c.findOrInstallVcluster(); err != nil {
+		return "", err
+	}
+
+	if _, exists := c.clusterExists(c.name); exists {
+		log.V(4).Info("Skipping vcluster Cluster.Create: cluster already created: ", c.name)
+		kConfig, err := c.getKubeconfig()
+		if err != nil {
+			return "", err
+		}
+		return kConfig, c.initKubernetesAccessClients()
+	}
+
+	if c.namespace != "" {
+		args = append(args, "--namespace", c.namespace)
+	}
+
+	if c.hostKubeContext != "" {
+		args = append(args, "--context", c.hostKubeContext)
+	}
+
+	command := fmt.Sprintf("%s create %s --connect=false --update-current=false", c.path, c.name)
+	if len(args) > 0 {
+		command = fmt.Sprintf("%s %s", command, strings.Join(args, " "))
+	}
+	log.V(4).Info("Launching:", command)
+	echo := gexe.New()
+	if c.hostKubeCfg != "" {
+		echo.SetEnv("KUBECONFIG", c.hostKubeCfg)
+	}
+
+	p := echo.RunProc(command)
+	if p.Err() != nil {
+		outBytes, err := io.ReadAll(p.Out())
+		if err != nil {
+			log.ErrorS(err, "failed to read data from the vcluster create process output due to an error")
+		}
+		return "", fmt.Errorf("vcluster: failed to create cluster %q: %s: %s: %s", c.name, p.Err(), p.Result(), string(outBytes))
+	}
+	clusters, ok := c.clusterExists(c.name)
+	if !ok {
+		return "", fmt.Errorf("vcluster Cluster.Create: cluster %v still not in 'cluster list' after creation: %v", c.name, clusters)
+	}
+	log.V(4).Info("vcluster clusters available: ", clusters)
+
+	kConfig, err := c.getKubeconfig()
+	if err != nil {
+		return "", err
+	}
+
+	return kConfig, nil
+}
+func (c *Cluster) CreateWithConfig(ctx context.Context, configFile string) (string, error) {
+	var args []string
+	if configFile != "" {
+		args = append(args, "--values", configFile)
+	}
+	return c.Create(ctx, args...)
+}
+func (c *Cluster) GetKubeconfig() string {
+	return c.kubecfgFile
+}
+
+type kubeconfig struct {
+	CurrentContext string `json:"current-context"`
+}
+
+func (c *Cluster) GetKubectlContext() string {
+	kc := &kubeconfig{}
+	raw, err := os.ReadFile(c.kubecfgFile)
+	if err != nil {
+		return ""
+	}
+	if err := yaml.Unmarshal(raw, kc); err != nil {
+		return ""
+	}
+	return kc.CurrentContext
+}
+func (c *Cluster) ExportLogs(ctx context.Context, dest string) error {
+	// Not implemented
+	return nil
+}
+func (c *Cluster) Destroy(ctx context.Context) error {
+	log.V(4).Info("Destroying vcluster ", c.name)
+	if err := c.findOrInstallVcluster(); err != nil {
+		return err
+	}
+
+	command := fmt.Sprintf("%s delete %s", c.path, c.name)
+	p := utils.RunCommand(command)
+	if p.Err() != nil {
+		outBytes, err := io.ReadAll(p.Out())
+		if err != nil {
+			log.ErrorS(err, "failed to read data from the vcluster delete process output due to an error")
+		}
+		return fmt.Errorf("vcluster: failed to delete cluster %q: %s: %s: %s", c.name, p.Err(), p.Result(), string(outBytes))
+	}
+
+	log.V(4).Info("Removing kubeconfig file ", c.kubecfgFile)
+	if err := os.Remove(c.kubecfgFile); err != nil {
+		return fmt.Errorf("vcluster: failed to remove kubeconfig file %q: %w", c.kubecfgFile, err)
+	}
+	return nil
+}
+
+func (c *Cluster) WaitForControlPlane(ctx context.Context, client klient.Client) error {
+	r, err := resources.New(client.RESTConfig())
+	if err != nil {
+		return err
+	}
+	for _, sl := range []metav1.LabelSelectorRequirement{
+		{Key: "k8s-app", Operator: metav1.LabelSelectorOpIn, Values: []string{"kube-dns"}},
+	} {
+		selector, err := metav1.LabelSelectorAsSelector(
+			&metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					sl,
+				},
+			},
+		)
+		if err != nil {
+			return err
+		}
+		err = wait.For(conditions.New(r).ResourceListN(&v1.PodList{}, len(sl.Values), resources.WithLabelSelector(selector.String())))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+func (c *Cluster) KubernetesRestConfig() *rest.Config {
+	return c.rc
+}
+
+// helpers to implement support.E2EClusterProvider
+func (c *Cluster) findOrInstallVcluster() error {
+	version := c.version
+	if c.version != "" {
+		version = vclusterVersion
+	}
+	path, err := utils.FindOrInstallGoBasedProvider(c.path, "vcluster", "github.com/loft-sh/vcluster/cmd/vcluster", version)
+	if path != "" {
+		c.path = path
+	}
+	return err
+}
+
+type clusterItem struct {
+	Name string `json:"Name"`
+}
+
+func (c *Cluster) clusterExists(name string) (string, bool) {
+	raw := utils.FetchCommandOutput(fmt.Sprintf("%s list --output json", c.path))
+	clusters := []clusterItem{}
+	if err := json.Unmarshal([]byte(raw), &clusters); err != nil {
+		return raw, false
+	}
+	for _, c := range clusters {
+		if c.Name == name {
+			return raw, true
+		}
+	}
+	return raw, false
+}
+
+func (c *Cluster) getKubeconfig() (string, error) {
+	kubecfg := fmt.Sprintf("%s-kubecfg", c.name)
+
+	var stdout, stderr bytes.Buffer
+	err := utils.RunCommandWithSeperatedOutput(fmt.Sprintf(`%s connect %s --print`, c.path, c.name), &stdout, &stderr)
+	if err != nil {
+		return "", fmt.Errorf("vcluster connect: stderr: %s: %w", stderr.String(), err)
+	}
+	log.V(4).Info("vcluster connect stderr \n", stderr.String())
+
+	file, err := os.CreateTemp("", fmt.Sprintf("vcluster-cluster-%s", kubecfg))
+	if err != nil {
+		return "", fmt.Errorf("vcluster kubeconfig file: %w", err)
+	}
+	defer file.Close()
+
+	c.kubecfgFile = file.Name()
+
+	if n, err := io.WriteString(file, stdout.String()); n == 0 || err != nil {
+		return "", fmt.Errorf("vcluster kubecfg file: bytes copied: %d: %w]", n, err)
+	}
+	return file.Name(), nil
+}
+
+func (c *Cluster) initKubernetesAccessClients() error {
+	cfg, err := conf.New(c.kubecfgFile)
+	if err != nil {
+		return err
+	}
+	c.rc = cfg
+	return nil
+}

--- a/third_party/vcluster/vcluster.go
+++ b/third_party/vcluster/vcluster.go
@@ -91,11 +91,11 @@ func WithHostKubeConfig(kubeconfig string) support.ClusterOpts {
 	}
 }
 
-func WithHostKubeContext(context string) support.ClusterOpts {
+func WithHostKubeContext(kubeContext string) support.ClusterOpts {
 	return func(c support.E2EClusterProvider) {
 		v, ok := c.(*Cluster)
 		if ok {
-			v.hostKubeContext = context
+			v.hostKubeContext = kubeContext
 		}
 	}
 }

--- a/third_party/vcluster/vcluster.go
+++ b/third_party/vcluster/vcluster.go
@@ -114,18 +114,21 @@ func (c *Cluster) WithPath(path string) support.E2EClusterProvider {
 	c.path = path
 	return c
 }
+
 func (c *Cluster) WithOpts(opts ...support.ClusterOpts) support.E2EClusterProvider {
 	for _, opt := range opts {
 		opt(c)
 	}
 	return c
 }
+
 func (c *Cluster) SetDefaults() support.E2EClusterProvider {
 	if c.path == "" {
 		c.path = "vcluster"
 	}
 	return c
 }
+
 func (c *Cluster) Create(ctx context.Context, args ...string) (string, error) {
 	log.V(4).Info("Creating vcluster ", c.name)
 	if err := c.findOrInstallVcluster(); err != nil {
@@ -180,6 +183,7 @@ func (c *Cluster) Create(ctx context.Context, args ...string) (string, error) {
 
 	return kConfig, nil
 }
+
 func (c *Cluster) CreateWithConfig(ctx context.Context, configFile string) (string, error) {
 	var args []string
 	if configFile != "" {
@@ -187,6 +191,7 @@ func (c *Cluster) CreateWithConfig(ctx context.Context, configFile string) (stri
 	}
 	return c.Create(ctx, args...)
 }
+
 func (c *Cluster) GetKubeconfig() string {
 	return c.kubecfgFile
 }
@@ -206,10 +211,12 @@ func (c *Cluster) GetKubectlContext() string {
 	}
 	return kc.CurrentContext
 }
+
 func (c *Cluster) ExportLogs(ctx context.Context, dest string) error {
 	// Not implemented
 	return nil
 }
+
 func (c *Cluster) Destroy(ctx context.Context) error {
 	log.V(4).Info("Destroying vcluster ", c.name)
 	if err := c.findOrInstallVcluster(); err != nil {
@@ -258,6 +265,7 @@ func (c *Cluster) WaitForControlPlane(ctx context.Context, client klient.Client)
 	}
 	return nil
 }
+
 func (c *Cluster) KubernetesRestConfig() *rest.Config {
 	return c.rc
 }

--- a/third_party/vcluster/vcluster_test.go
+++ b/third_party/vcluster/vcluster_test.go
@@ -1,0 +1,11 @@
+package vcluster
+
+import "testing"
+
+func TestCluster_VclusterInstall(t *testing.T) {
+	c := Cluster{}
+	err := c.findOrInstallVcluster()
+	if err != nil {
+		t.Fatalf("Error installing vcluster: %v", err)
+	}
+}


### PR DESCRIPTION
addition of vcluster provider; interested to see if the CI fails. vcluster needs a "host" cluster to launch into, so I've followed an existing example where a real cluster or kind cluster are utilized as necessary: https://github.com/kubernetes-sigs/e2e-framework/blob/9206e6f6082907a1c77750b7cac0fc44ff4dac02/examples/real_cluster/main_test.go#L39

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR enables a new `E2EClusterProvider` for `vcluster` based clusters.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


#### Additional documentation e.g., Usage docs, etc.:

```docs
NA
```