### PR TITLE
feat: allow accessing the test environments env config

### DIFF
--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -363,6 +363,12 @@ func (e *testEnv) Finish(funcs ...Func) types.Environment {
 	return e
 }
 
+// EnvConf returns the test environment's environment configuration
+func (e *testEnv) EnvConf() *envconf.Config {
+	cfg := *e.cfg
+	return &cfg
+}
+
 // Run is to launch the test suite from a TestMain function.
 // It will run m.Run() and exercise all test functions in the
 // package.  This method will all Env.Setup operations prior to

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -85,6 +85,9 @@ type Environment interface {
 
 	// Run Launches the test suite from within a TestMain
 	Run(*testing.M) int
+
+	// EnvConf returns the test environment's environment configuration
+	EnvConf() *envconf.Config
 }
 
 type Labels = flags.LabelsMap


### PR DESCRIPTION

#### What type of PR is this?


/kind feature

#### What this PR does / why we need it:

This pull request adds a function to the `types.Environment` kind that allows access of the environment configuration used by the test environment. This may allow for ad-hoc uses cases not supported by the test suite, such as: https://github.com/kubernetes-sigs/e2e-framework/issues/268 

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter the details of what chanages are being introduced:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NA
```


#### Additional documentation e.g., Usage docs, etc.:

<!--
When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NA
```