### PR TITLE
Extend GetKubeconfig methods with args

### DIFF
--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -196,6 +196,11 @@ type E2EClusterProvider interface {
 	// using the cluster provider native way
 	GetKubeconfig() string
 
+	// GetLatestKubeconfig provides a way to extract the kubeconfig file associated with the cluster in question.
+	// Different from GetKubeconfig, this method is used to extract the kubeconfig using provider native way, where the GetKubeconfig is cached.
+	// It is useful in cases where the kubeconfig file is required to be extracted multiple times during the test run with different arguments.
+	GetLatestKubeconfig(args ...string) (string, error)
+
 	// GetKubectlContext is used to extract the kubectl context to be used while performing the operation
 	GetKubectlContext() string
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -196,10 +196,10 @@ type E2EClusterProvider interface {
 	// using the cluster provider native way
 	GetKubeconfig() string
 
-	// GetLatestKubeconfig provides a way to extract the kubeconfig file associated with the cluster in question.
+	// GenerateKubeconfig provides a way to extract the kubeconfig file associated with the cluster in question.
 	// Different from GetKubeconfig, this method is used to extract the kubeconfig using provider native way, where the GetKubeconfig is cached.
 	// It is useful in cases where the kubeconfig file is required to be extracted multiple times during the test run with different arguments.
-	GetLatestKubeconfig(args ...string) (string, error)
+	GenerateKubeconfig(args ...string) (string, error)
 
 	// GetKubectlContext is used to extract the kubectl context to be used while performing the operation
 	GetKubectlContext() string

--- a/third_party/k3d/k3d.go
+++ b/third_party/k3d/k3d.go
@@ -251,7 +251,7 @@ func (c *Cluster) GetKubectlContext() string {
 	return fmt.Sprintf("k3d-%s", c.name)
 }
 
-func (c *Cluster) GetLatestKubeconfig(args ...string) (string, error) {
+func (c *Cluster) GenerateKubeconfig(args ...string) (string, error) {
 	return c.getKubeConfig(args...)
 }
 

--- a/third_party/k3d/k3d.go
+++ b/third_party/k3d/k3d.go
@@ -106,11 +106,12 @@ func (c *Cluster) findOrInstallK3D() error {
 	return err
 }
 
-func (c *Cluster) getKubeConfig() (string, error) {
+func (c *Cluster) getKubeConfig(args ...string) (string, error) {
 	kubeCfg := fmt.Sprintf("%s-kubecfg", c.name)
 
 	var stdout, stderr bytes.Buffer
-	err := utils.RunCommandWithSeperatedOutput(fmt.Sprintf("%s kubeconfig get %s", c.path, c.name), &stdout, &stderr)
+	cmd := fmt.Sprintf("%s kubeconfig get %s %s", c.path, strings.Join(args, " "), c.name)
+	err := utils.RunCommandWithSeperatedOutput(cmd, &stdout, &stderr)
 	if err != nil {
 		return "", fmt.Errorf("failed to get kubeconfig: %s", stderr.String())
 	}
@@ -248,6 +249,10 @@ func (c *Cluster) GetKubeconfig() string {
 
 func (c *Cluster) GetKubectlContext() string {
 	return fmt.Sprintf("k3d-%s", c.name)
+}
+
+func (c *Cluster) GetLatestKubeconfig(args ...string) (string, error) {
+	return c.getKubeConfig(args...)
 }
 
 func (c *Cluster) ExportLogs(ctx context.Context, dest string) error {

--- a/third_party/kind/kind.go
+++ b/third_party/kind/kind.go
@@ -308,6 +308,6 @@ func (k *Cluster) KubernetesRestConfig() *rest.Config {
 	return k.rc
 }
 
-func (k *Cluster) GetLatestKubeconfig(args ...string) (string, error) {
+func (k *Cluster) GenerateKubeconfig(args ...string) (string, error) {
 	return k.getKubeconfig(args...)
 }

--- a/third_party/kind/kind.go
+++ b/third_party/kind/kind.go
@@ -107,11 +107,11 @@ func (k *Cluster) WithOpts(opts ...support.ClusterOpts) support.E2EClusterProvid
 	return k
 }
 
-func (k *Cluster) getKubeconfig() (string, error) {
+func (k *Cluster) getKubeconfig(args ...string) (string, error) {
 	kubecfg := fmt.Sprintf("%s-kubecfg", k.name)
 
 	var stdout, stderr bytes.Buffer
-	err := utils.RunCommandWithSeperatedOutput(fmt.Sprintf(`%s get kubeconfig --name %s`, k.path, k.name), &stdout, &stderr)
+	err := utils.RunCommandWithSeperatedOutput(fmt.Sprintf(`%s get kubeconfig %s --name %s`, k.path, strings.Join(args, " "), k.name), &stdout, &stderr)
 	if err != nil {
 		return "", fmt.Errorf("kind get kubeconfig: stderr: %s: %w", stderr.String(), err)
 	}
@@ -306,4 +306,8 @@ func (k *Cluster) WaitForControlPlane(ctx context.Context, client klient.Client)
 
 func (k *Cluster) KubernetesRestConfig() *rest.Config {
 	return k.rc
+}
+
+func (k *Cluster) GetLatestKubeconfig(args ...string) (string, error) {
+	return k.getKubeconfig(args...)
 }

--- a/third_party/kwok/kwok.go
+++ b/third_party/kwok/kwok.go
@@ -281,6 +281,6 @@ func (k *Cluster) KubernetesRestConfig() *rest.Config {
 	return k.rc
 }
 
-func (k *Cluster) GetLatestKubeconfig(args ...string) (string, error) {
+func (k *Cluster) GenerateKubeconfig(args ...string) (string, error) {
 	return k.getKubeconfig(args...)
 }

--- a/third_party/kwok/kwok.go
+++ b/third_party/kwok/kwok.go
@@ -94,12 +94,12 @@ func (k *Cluster) clusterExists(name string) (string, bool) {
 	return clusters, false
 }
 
-func (k *Cluster) getKubeconfig() (string, error) {
+func (k *Cluster) getKubeconfig(args ...string) (string, error) {
 	kubecfg := fmt.Sprintf("%s-kubecfg", k.name)
 
 	var stdout, stderr bytes.Buffer
-	err := utils.RunCommandWithSeperatedOutput(fmt.Sprintf(`%s get kubeconfig --name %s`,
-		k.path, k.name), &stdout, &stderr)
+	cmd := fmt.Sprintf(`%s get kubeconfig %s --name %s`, k.path, strings.Join(args, " "), k.name)
+	err := utils.RunCommandWithSeperatedOutput(cmd, &stdout, &stderr)
 	if err != nil {
 		return "", fmt.Errorf("kwokctl get kubeconfig: stderr: %s: %w", stderr.String(), err)
 	}
@@ -279,4 +279,8 @@ func (k *Cluster) WithVersion(version string) support.E2EClusterProvider {
 
 func (k *Cluster) KubernetesRestConfig() *rest.Config {
 	return k.rc
+}
+
+func (k *Cluster) GetLatestKubeconfig(args ...string) (string, error) {
+	return k.getKubeconfig(args...)
 }

--- a/third_party/vcluster/vcluster.go
+++ b/third_party/vcluster/vcluster.go
@@ -276,7 +276,7 @@ func (c *Cluster) KubernetesRestConfig() *rest.Config {
 	return c.rc
 }
 
-func (c *Cluster) GetLatestKubeconfig(args ...string) (string, error) {
+func (c *Cluster) GenerateKubeconfig(args ...string) (string, error) {
 	return c.getKubeconfig(args...)
 }
 

--- a/third_party/vcluster/vcluster.go
+++ b/third_party/vcluster/vcluster.go
@@ -276,6 +276,10 @@ func (c *Cluster) KubernetesRestConfig() *rest.Config {
 	return c.rc
 }
 
+func (c *Cluster) GetLatestKubeconfig(args ...string) (string, error) {
+	return c.getKubeconfig(args...)
+}
+
 // helpers to implement support.E2EClusterProvider
 func (c *Cluster) findOrInstallVcluster() error {
 	version := c.version
@@ -307,11 +311,12 @@ func (c *Cluster) clusterExists(name string) (string, bool) {
 	return raw, false
 }
 
-func (c *Cluster) getKubeconfig() (string, error) {
+func (c *Cluster) getKubeconfig(args ...string) (string, error) {
 	kubecfg := fmt.Sprintf("%s-kubecfg", c.name)
 
 	var stdout, stderr bytes.Buffer
-	err := utils.RunCommandWithSeperatedOutput(fmt.Sprintf(`%s connect %s --print`, c.path, c.name), &stdout, &stderr)
+	cmd := fmt.Sprintf(`%s connect %s --print %s`, c.path, c.name, strings.Join(args, " "))
+	err := utils.RunCommandWithSeperatedOutput(cmd, &stdout, &stderr)
 	if err != nil {
 		return "", fmt.Errorf("vcluster connect: stderr: %s: %w", stderr.String(), err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

When dealing with multi-cluster setup we ran into issue where we need to pass arguments into `GetKubeconfig` method. 
Specific example in our case was `--internal` to `kind` so cluster can speak to different clusters.

This extends this so you can do things like:
```
internalKubeConfigOpts := kind.WithGetKubeConfigArgs("--internal")
		internalKubeConfig, err := kindEdgeCluster.WithOpts(internalKubeConfigOpts).GetLiveKubeconfig()
		if err != nil {
			log.Printf("Failed to get edge cluster kubeconfig: %s", err)
			return ctx, err
		}
		installCmd := fmt.Sprintf(
			`bash -c "KUBECONFIG=%s kubectl create secret generic edge-cluster-kubeconfig -n omni-operator-system  --from-file=kubeconfig=%s"`,
			kindMasterCluster.GetKubeconfig(),
			internalKubeConfig,
		)
```

Or similar pattern if you want to set this for all `cluster` object. 
In addition to allow networking we did this:
```
os.Setenv("KIND_EXPERIMENTAL_DOCKER_NETWORK", "kind-test")
	testEnv.Setup(
		envfuncs.CreateCluster(kindMasterCluster, kindMasterClusterName),
		envfuncs.CreateNamespace(namespace),
		setupFunc,
		installDepsFunc,
		generateAndDeployFunc,
		envfuncs.CreateClusterWithConfig(kindEdgeCluster, kindEdgeClusterName, "edge-kind.yaml"), // must be after master cluster setup.
		joinMasterClusterPrerequisitesFunc,
	)
```

Im not super exited about naming of `GetLiveKubeconfig` so any suggestions are welcome 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter the details of what chanages are being introduced:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
```


#### Additional documentation e.g., Usage docs, etc.:

<!--
When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```