### PR TITLE
Add `WithWaitDuration` ClusterOpts function

### DIFF
--- a/support/kwok/kwok.go
+++ b/support/kwok/kwok.go
@@ -23,7 +23,8 @@ import (
 type Cluster = tptkwok.Cluster
 
 var (
-	NewCluster  = tptkwok.NewCluster
-	NewProvider = tptkwok.NewProvider
-	WithPath    = tptkwok.WithPath
+	NewCluster       = tptkwok.NewCluster
+	NewProvider      = tptkwok.NewProvider
+	WithPath         = tptkwok.WithPath
+	WithWaitDuration = tptkwok.WithWaitDuration
 )

--- a/third_party/kwok/kwok.go
+++ b/third_party/kwok/kwok.go
@@ -64,6 +64,15 @@ func WithPath(path string) support.ClusterOpts {
 	}
 }
 
+func WithWaitDuration(waitDuration time.Duration) support.ClusterOpts {
+	return func(c support.E2EClusterProvider) {
+		k, ok := c.(*Cluster)
+		if ok {
+			k.waitDuration = waitDuration
+		}
+	}
+}
+
 func (k *Cluster) findOrInstallKwokCtl() error {
 	if k.version != "" {
 		kwokVersion = k.version


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This allows `kwok` clusters to be created with a custom wait time option.

#### Which issue(s) this PR fixes:
Fixes #478

#### Special notes for your reviewer:
I wasn't sure if it was better to have a receiver method on `*Cluster` or use the `ClusterOptions`. I couldn't find a concrete usage example of the Cluster Options for `kwok` anywhere, but thought it to be the least impactful change to allow this feature to be set. This is my first PR to the e2e-framework, so any feedback is appreciated!

#### Does this PR introduce a user-facing change?
```release-note
NONE
```