### PR TITLE
Add ExecInDeployment method

### DIFF
--- a/examples/exec_in_deployment/README.md
+++ b/examples/exec_in_deployment/README.md
@@ -1,0 +1,23 @@
+# Execute Commands in a Deployment
+
+This package demonstrates how to use `ExecInDeployment` to execute commands inside a specific deployment.
+
+`ExecInDeployment` mimics the behavior of `kubectl exec -it -n <namespace> deploy/<deployment> -- <command>`: it selects the first pod of the specified deployment and runs the command in the first container of that pod.
+
+It provides a convenient way to run a command using only the deployment name — similar to `ExecInPod`, but for deployments, and defaulting to the first container of the first pod.
+
+`ExecInDeployment` expects the deployment with the specified name to exist and be available.
+
+## Example
+
+Fetch metrics from the `http://localhost:8080/metrics` endpoint in the deployment `controller` running in the namespace `default`:
+```go
+var stdout, stderr *bytes.Buffer
+cmd := []string{"wget", "-qO-", "http://localhost:8080/metrics"}
+if err := c.Client().Resources().ExecInDeployment(ctx, "default", "controller", cmd, &stdout, &stderr); err != nil {
+  t.Log(stderr.String())
+  t.Fatal(err)
+}
+
+metrics := stdout.String()
+```

--- a/examples/exec_in_deployment/exec_in_deployment_test.go
+++ b/examples/exec_in_deployment/exec_in_deployment_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package exec_in_deployment
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/e2e-framework/klient/wait"
+	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+)
+
+type ctxKey string
+
+func TestExecInDeployment(t *testing.T) {
+	deploymentCtxKey := ctxKey("deployment")
+
+	feature := features.New("ExecInDeployment").
+		Setup(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+			resources := c.Client().Resources()
+
+			deployment := newDeployment(c.Namespace())
+			if err := resources.Create(ctx, deployment); err != nil {
+				t.Fatal(err)
+			}
+
+			if err := wait.For(
+				conditions.New(resources).DeploymentAvailable(deployment.Name, c.Namespace()),
+				wait.WithTimeout(time.Minute*1)); err != nil {
+				t.Fatal(err)
+			}
+
+			return context.WithValue(ctx, deploymentCtxKey, deployment)
+		}).
+		Assess("executes commands in an existing deployment", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+			deployment := ctx.Value(deploymentCtxKey).(*appsv1.Deployment)
+			message := "foo bar baz"
+
+			var stdout, stderr bytes.Buffer
+			cmd := []string{"echo", "-n", message}
+			if err := c.Client().Resources().ExecInDeployment(ctx, c.Namespace(), deployment.Name, cmd, &stdout, &stderr); err != nil {
+				t.Log(stderr.String())
+				t.Fatal(err)
+			}
+
+			if stdout.String() != message {
+				t.Fatalf("Expected %q, got %q", message, stdout.String())
+			}
+
+			return ctx
+		}).
+		Assess("returns error for non-existent deployments", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+			var stdout, stderr bytes.Buffer
+			cmd := []string{"echo", "should not happen"}
+			err := c.Client().Resources().ExecInDeployment(ctx, c.Namespace(), "does-not-exist", cmd, &stdout, &stderr)
+
+			if err == nil {
+				t.Fatal("Expected an error, got nil")
+			}
+
+			return ctx
+		}).
+		Feature()
+
+	testEnv.Test(t, feature)
+}
+
+func newDeployment(namespace string) *appsv1.Deployment {
+	labels := map[string]string{"app": "exec-in-deployment"}
+	replicas := int32(1)
+
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: namespace},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: labels,
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: labels},
+				Spec: corev1.PodSpec{Containers: []corev1.Container{{
+					Name:    "alpine",
+					Image:   "alpine",
+					Command: []string{"sleep", "infinity"},
+				}}},
+			},
+		},
+	}
+}

--- a/examples/exec_in_deployment/main_test.go
+++ b/examples/exec_in_deployment/main_test.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package exec_in_deployment
+
+import (
+	"os"
+	"testing"
+
+	"sigs.k8s.io/e2e-framework/pkg/env"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/envfuncs"
+	"sigs.k8s.io/e2e-framework/support/kind"
+)
+
+var testEnv env.Environment
+
+func TestMain(m *testing.M) {
+	cfg, _ := envconf.NewFromFlags()
+	testEnv = env.NewWithConfig(cfg)
+	clusterName := envconf.RandomName("deployment-exec", 24)
+	namespaceName := envconf.RandomName("my-ns", 10)
+
+	testEnv.Setup(
+		envfuncs.CreateCluster(kind.NewProvider(), clusterName),
+		envfuncs.CreateNamespace(namespaceName),
+	)
+
+	testEnv.Finish(
+		envfuncs.DeleteNamespace(namespaceName),
+		envfuncs.DestroyCluster(clusterName),
+	)
+
+	os.Exit(testEnv.Run(m))
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This patch adds the `ExecInDeployment` method, which works similarly to
```shell
$ kubectl exec -n <namespace> -it deploy/<deployment> -- <command>
```

It's useful when you need to run a command from one of the pods belonging to a specific deployment, but you don't care which one.

For example, suppose there's a deployment running a custom controller, and you need to assert metrics written by that controller. The metrics endpoint is exposed via a `Service`, so it doesn't really matter which pod you call it from.

Instead of manually retrieving the list of pods belonging to the deployment, selecting one and passing it to `ExecInPod`, you could do this:
```go
var stdout, stderr *bytes.Buffer
cmd := []string{"wget", "-qO-", fmt.Sprintf("http://my-service.%s.svc:8080/metrics", c.Namespace())}
if err := c.Client().Resources().ExecInDeployment(ctx, c.Namespace(), deployment.Name, cmd, &stdout, &stderr); err != nil {
  t.Log(stderr.String())
  t.Fatal(err)
}
metrics := stdout.String()
```

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Added the Resources.ExecInDeployment method, which finds a deployment by name and runs the command in the first container of the first pod in that deployment
```

#### Additional documentation e.g., Usage docs, etc.:

```docs
```
