### PR TITLE
docs: fix incorrect parameters in example doc

### DIFF
--- a/docs/klient-package.md
+++ b/docs/klient-package.md
@@ -74,7 +74,8 @@ import (
 type ListOptions struct{ ... }
 type ListOptFunc func(*ListOptions)
 
-func (_ Resource) List(ctx context.Context, namespace string, l ObjectList, opts ...ListOption) error
+
+func (r *Resources) List(ctx context.Context, objs k8s.ObjectList, opts ...ListOption) error
 ```
 
 Optional parameters can be omitted from the call (as shown below), in which case the framework would use sensible default values where applicable.
@@ -82,11 +83,11 @@ Optional parameters can be omitted from the call (as shown below), in which case
 ```go
 func main() {
     var deps v1.DeploymentList
-    if res.List(
+    if err := res.List(
         context.TODO(), 
-        "default", &deps, 
-        func(opts *metav1.ListOptions){opts.Labels="tier=web"}); err != nil {
-        log.Fatal("unable to list deployments ", err)   
+        &deps,
+        ); err != nil {
+          log.Fatal("unable to list deployments ", err)
     }
 }
 ```
@@ -96,11 +97,11 @@ func main() {
 ```go
 func main() {
     var deps v1.DeploymentList
-    if res.List(
+    if err := res.List(
         context.TODO(), 
-        "default", &deps, 
-        WithLabelSelector("tier=web")); err != nil {
-        log.Fatal("unable to list deployments ", err)   
+        &deps, 
+        resources.WithLabelSelector("tier=web")); err != nil {
+          log.Fatal("unable to list deployments ", err)
     }
 }
 ```
@@ -113,12 +114,12 @@ For instance, if we assume that type `ListOptions` includes a `RetryTimeout` fie
 ```go
 func main() {
     var deps v1.DeploymentList
-    if res.List(
+    if err := res.List(
         context.TODO(), 
-        "default", &deps, 
+        &deps,
         func(opts *ListOptions){opts.Labels="tier=web"}
         func(opts *ListOptions){opts.RetryTimeout=time.Seconds*30}); err != nil {
-        log.Fatal("unable to list deployments ", err)   
+          log.Fatal("unable to list deployments ", err)
     }
 }
 ```


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:
Fixes incorrect documentation that suggested namespace could be passed as an option to the `List()` method. The correct usage is to pass namespace to the `Resources()` method instead. Updated documentation to show the proper usage of `List()`.

#### Which issue(s) this PR fixes:

Fixes #503 

#### Special notes for your reviewer:
The documentation was misleading users about the correct API usage. This change aligns the docs with the actual implementation where namespace is passed to `Resources(namespace)` rather than as a `List()` option.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter the details of what changes are being introduced:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```


#### Additional documentation e.g., Usage docs, etc.:

<!--
When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```