### PR TITLE
feat: expose DeleteOptions in envfuncs.DeleteNamespace

### DIFF
--- a/pkg/envfuncs/ns_funcs.go
+++ b/pkg/envfuncs/ns_funcs.go
@@ -23,6 +23,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/e2e-framework/klient"
+	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
 	"sigs.k8s.io/e2e-framework/pkg/env"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 )
@@ -73,7 +74,7 @@ func CreateNamespace(name string, opts ...CreateNamespaceOpts) env.Func {
 // DeleteNamespace provides an Environment.Func that deletes the named
 // namespace. It first searches for the ns in its context, if not found then
 // attempt to retrieve it from the API server. Then deletes it.
-func DeleteNamespace(name string) env.Func {
+func DeleteNamespace(name string, opts ...resources.DeleteOption) env.Func {
 	return func(ctx context.Context, cfg *envconf.Config) (context.Context, error) {
 		var namespace *corev1.Namespace
 
@@ -105,7 +106,7 @@ func DeleteNamespace(name string) env.Func {
 		}
 
 		// remove namespace api object
-		if err := client.Resources().Delete(ctx, namespace); err != nil {
+		if err := client.Resources().Delete(ctx, namespace, opts...); err != nil {
 			return ctx, fmt.Errorf("delete namespace func: %w", err)
 		}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

I want to delete a test's namespace in the foreground, to ensure the namespace is not left `Terminating` after the test completes.

I've exposed the `resources.DeleteOptions` to make this possible using `resources.WithDeletePropagation`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter the details of what changes are being introduced:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
envfuncs.DeleteNamespace now accepts resources.DeleteOptions.
```


#### Additional documentation e.g., Usage docs, etc.:

<!--
When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```