### PR TITLE
fix: Pass context to cluster providers when creating clusters

### DIFF
--- a/pkg/utils/command.go
+++ b/pkg/utils/command.go
@@ -111,8 +111,16 @@ func RunCommandContext(ctx context.Context, command string) *exec.Proc {
 
 // RunCommandWithSeperatedOutput run command and returns the results to the provided
 // stdout and stderr io.Writer.
+//
+// Deprecated: Use RunCommandWithSeperatedOutputContext instead and provide a context to.
 func RunCommandWithSeperatedOutput(command string, stdout, stderr io.Writer) error {
-	p := commandRunner.NewProc(command)
+	return RunCommandWithSeperatedOutputContext(context.Background(), command, stdout, stderr)
+}
+
+// RunCommandWithSeperatedOutputContext run command with the provided context
+// and returns the results to the provided stdout and stderr io.Writer.
+func RunCommandWithSeperatedOutputContext(ctx context.Context, command string, stdout, stderr io.Writer) error {
+	p := commandRunner.NewProcWithContext(ctx, command)
 	p.SetStdout(stdout)
 	p.SetStderr(stderr)
 	result := p.Run()

--- a/pkg/utils/command.go
+++ b/pkg/utils/command.go
@@ -18,6 +18,7 @@ package utils
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 
@@ -93,9 +94,19 @@ func FindOrInstallGoBasedProvider(pPath, provider, module, version string) (stri
 	return "", fmt.Errorf("%s not available even after installation", provider)
 }
 
-// RunCommand run command and returns an *exec.Proc with information about the executed process.
+// RunCommand runs the command and returns an *exec.Proc with information about the executed process.
+//
+// Deprecated: Please use RunCommandContext instead and provide a context to
+// make sure the command execution can be cancelled if needed.
 func RunCommand(command string) *exec.Proc {
-	return commandRunner.RunProc(command)
+	ctx := context.Background()
+	return RunCommandContext(ctx, command)
+}
+
+// RunCommand runs the command with the provided context and returns an
+// *exec.Proc with information about the executed process.
+func RunCommandContext(ctx context.Context, command string) *exec.Proc {
+	return commandRunner.RunProcWithContext(ctx, command)
 }
 
 // RunCommandWithSeperatedOutput run command and returns the results to the provided
@@ -109,10 +120,19 @@ func RunCommandWithSeperatedOutput(command string, stdout, stderr io.Writer) err
 	return result.Err()
 }
 
-// RunCommandWithCustomWriter run command and returns an *exec.Proc with information about the executed process.
+// RunCommandWithCustomWriterContext run command and returns an *exec.Proc with information about the executed process.
 // This helps map the STDOUT/STDERR to custom writer to extract data from the output.
+//
+// Deprecated: Use RunCommandWithCustomWriterContext instead and provide a
+// context to make sure the command execution can be cancelled if needed.
 func RunCommandWithCustomWriter(command string, stdout, stderr io.Writer) *exec.Proc {
-	p := commandRunner.NewProc(command)
+	return RunCommandWithCustomWriterContext(context.Background(), command, stdout, stderr)
+}
+
+// RunCommandWithCustomWriterContext run command and returns an *exec.Proc with information about the executed process.
+// This helps map the STDOUT/STDERR to custom writer to extract data from the output.
+func RunCommandWithCustomWriterContext(ctx context.Context, command string, stdout, stderr io.Writer) *exec.Proc {
+	p := commandRunner.NewProcWithContext(ctx, command)
 	p.SetStdout(stdout)
 	p.SetStderr(stderr)
 	return p.Run()

--- a/third_party/k3d/k3d.go
+++ b/third_party/k3d/k3d.go
@@ -142,10 +142,10 @@ func (c *Cluster) clusterExists(name string) (string, bool) {
 	return clusters, false
 }
 
-func (c *Cluster) startCluster(name string) error {
+func (c *Cluster) startCluster(ctx context.Context, name string) error {
 	cmd := fmt.Sprintf("%s cluster start %s", c.path, name)
 	log.V(4).InfoS("Starting k3d cluster", "command", cmd)
-	p := utils.RunCommand(cmd)
+	p := utils.RunCommandContext(ctx, cmd)
 	if p.Err() != nil {
 		return fmt.Errorf("k3d: failed to start cluster %q: %s: %s", name, p.Err(), p.Result())
 	}
@@ -193,7 +193,7 @@ func (c *Cluster) Create(ctx context.Context, args ...string) (string, error) {
 		// This is being done as an extra step to ensure that in case you have the cluster by the same name, but it is not up.
 		// Starting an already started cluster won't cause any harm. So, we will just start it once before continuing
 		// further down the line and process rest of the workflows
-		if err := c.startCluster(c.name); err != nil {
+		if err := c.startCluster(ctx, c.name); err != nil {
 			return "", err
 		}
 		log.V(4).InfoS("Skipping k3d cluster creation. Cluster already exists", "name", c.name)
@@ -218,7 +218,7 @@ func (c *Cluster) Create(ctx context.Context, args ...string) (string, error) {
 
 	var stdout, stderr bytes.Buffer
 
-	p := utils.RunCommandWithCustomWriter(cmd, &stdout, &stderr)
+	p := utils.RunCommandWithCustomWriterContext(ctx, cmd, &stdout, &stderr)
 	if p.Err() != nil {
 		return "", fmt.Errorf("k3d: failed to create cluster %q: %s: %s: %s %s", c.name, p.Err(), p.Result(), stdout.String(), stderr.String())
 	}
@@ -273,7 +273,7 @@ func (c *Cluster) Destroy(ctx context.Context) error {
 
 	cmd := fmt.Sprintf("%s cluster delete %s", c.path, c.name)
 	log.V(4).InfoS("Destroying k3d cluster", "command", cmd)
-	p := utils.RunCommand(cmd)
+	p := utils.RunCommandContext(ctx, cmd)
 	if p.Err() != nil {
 		outBytes, err := io.ReadAll(p.Out())
 		if err != nil {
@@ -307,7 +307,7 @@ func (c *Cluster) KubernetesRestConfig() *rest.Config {
 
 func (c *Cluster) LoadImage(ctx context.Context, image string, args ...string) error {
 	log.V(4).InfoS("Performing Image load operation", "cluster", c.name, "image", image, "args", args)
-	p := utils.RunCommand(fmt.Sprintf("%s image import --cluster %s %s %s", c.path, c.name, strings.Join(args, " "), image))
+	p := utils.RunCommandContext(ctx, fmt.Sprintf("%s image import --cluster %s %s %s", c.path, c.name, strings.Join(args, " "), image))
 	if p.Err() != nil {
 		return fmt.Errorf("k3d: load docker-image %v failed: %s: %s", image, p.Err(), p.Result())
 	}
@@ -383,7 +383,7 @@ func (c *Cluster) StopNode(ctx context.Context, node *support.Node, args ...stri
 
 func (c *Cluster) ListNode(ctx context.Context, args ...string) ([]support.Node, error) {
 	cmd := fmt.Sprintf("%s node list -o json", c.path)
-	p := utils.RunCommand(cmd)
+	p := utils.RunCommandContext(ctx, cmd)
 	if p.Err() != nil || (p.Exited() && p.ExitCode() != 0) {
 		return nil, fmt.Errorf("k3d: failed to list nodes: %s: %s", p.Err(), p.Result())
 	}

--- a/third_party/k3d/k3d.go
+++ b/third_party/k3d/k3d.go
@@ -106,12 +106,12 @@ func (c *Cluster) findOrInstallK3D() error {
 	return err
 }
 
-func (c *Cluster) getKubeConfig(args ...string) (string, error) {
+func (c *Cluster) getKubeConfig(ctx context.Context, args ...string) (string, error) {
 	kubeCfg := fmt.Sprintf("%s-kubecfg", c.name)
 
 	var stdout, stderr bytes.Buffer
 	cmd := fmt.Sprintf("%s kubeconfig get %s %s", c.path, strings.Join(args, " "), c.name)
-	err := utils.RunCommandWithSeperatedOutput(cmd, &stdout, &stderr)
+	err := utils.RunCommandWithSeperatedOutputContext(ctx, cmd, &stdout, &stderr)
 	if err != nil {
 		return "", fmt.Errorf("failed to get kubeconfig: %s", stderr.String())
 	}
@@ -197,7 +197,7 @@ func (c *Cluster) Create(ctx context.Context, args ...string) (string, error) {
 			return "", err
 		}
 		log.V(4).InfoS("Skipping k3d cluster creation. Cluster already exists", "name", c.name)
-		kConfig, err := c.getKubeConfig()
+		kConfig, err := c.getKubeConfig(ctx)
 		if err != nil {
 			return "", err
 		}
@@ -228,7 +228,7 @@ func (c *Cluster) Create(ctx context.Context, args ...string) (string, error) {
 	}
 	log.V(4).Info("k3d clusters available: ", clusters)
 
-	kConfig, err := c.getKubeConfig()
+	kConfig, err := c.getKubeConfig(ctx)
 	if err != nil {
 		return "", err
 	}
@@ -252,7 +252,7 @@ func (c *Cluster) GetKubectlContext() string {
 }
 
 func (c *Cluster) GenerateKubeconfig(args ...string) (string, error) {
-	return c.getKubeConfig(args...)
+	return c.getKubeConfig(context.Background(), args...)
 }
 
 func (c *Cluster) ExportLogs(ctx context.Context, dest string) error {

--- a/third_party/kind/kind.go
+++ b/third_party/kind/kind.go
@@ -107,11 +107,11 @@ func (k *Cluster) WithOpts(opts ...support.ClusterOpts) support.E2EClusterProvid
 	return k
 }
 
-func (k *Cluster) getKubeconfig(args ...string) (string, error) {
+func (k *Cluster) getKubeconfig(ctx context.Context, args ...string) (string, error) {
 	kubecfg := fmt.Sprintf("%s-kubecfg", k.name)
 
 	var stdout, stderr bytes.Buffer
-	err := utils.RunCommandWithSeperatedOutput(fmt.Sprintf(`%s get kubeconfig %s --name %s`, k.path, strings.Join(args, " "), k.name), &stdout, &stderr)
+	err := utils.RunCommandWithSeperatedOutputContext(ctx, fmt.Sprintf(`%s get kubeconfig %s --name %s`, k.path, strings.Join(args, " "), k.name), &stdout, &stderr)
 	if err != nil {
 		return "", fmt.Errorf("kind get kubeconfig: stderr: %s: %w", stderr.String(), err)
 	}
@@ -158,7 +158,7 @@ func (k *Cluster) Create(ctx context.Context, args ...string) (string, error) {
 
 	if _, ok := k.clusterExists(k.name); ok {
 		log.V(4).Info("Skipping Kind Cluster.Create: cluster already created: ", k.name)
-		kConfig, err := k.getKubeconfig()
+		kConfig, err := k.getKubeconfig(ctx)
 		if err != nil {
 			return "", err
 		}
@@ -188,7 +188,7 @@ func (k *Cluster) Create(ctx context.Context, args ...string) (string, error) {
 	}
 	log.V(4).Info("kind clusters available: ", clusters)
 
-	kConfig, err := k.getKubeconfig()
+	kConfig, err := k.getKubeconfig(ctx)
 	if err != nil {
 		return "", err
 	}
@@ -309,5 +309,5 @@ func (k *Cluster) KubernetesRestConfig() *rest.Config {
 }
 
 func (k *Cluster) GenerateKubeconfig(args ...string) (string, error) {
-	return k.getKubeconfig(args...)
+	return k.getKubeconfig(context.Background(), args...)
 }

--- a/third_party/kind/kind.go
+++ b/third_party/kind/kind.go
@@ -174,7 +174,7 @@ func (k *Cluster) Create(ctx context.Context, args ...string) (string, error) {
 		command = fmt.Sprintf("%s %s", command, strings.Join(args, " "))
 	}
 	log.V(4).Info("Launching:", command)
-	p := utils.RunCommand(command)
+	p := utils.RunCommandContext(ctx, command)
 	if p.Err() != nil {
 		outBytes, err := io.ReadAll(p.Out())
 		if err != nil {
@@ -219,7 +219,7 @@ func (k *Cluster) ExportLogs(ctx context.Context, dest string) error {
 		return err
 	}
 
-	p := utils.RunCommand(fmt.Sprintf(`%s export logs %s --name %s`, k.path, dest, k.name))
+	p := utils.RunCommandContext(ctx, fmt.Sprintf(`%s export logs %s --name %s`, k.path, dest, k.name))
 	if p.Err() != nil {
 		return fmt.Errorf("kind: export cluster %v logs failed: %s: %s", k.name, p.Err(), p.Result())
 	}
@@ -233,7 +233,7 @@ func (k *Cluster) Destroy(ctx context.Context) error {
 		return err
 	}
 
-	p := utils.RunCommand(fmt.Sprintf(`%s delete cluster --name %s`, k.path, k.name))
+	p := utils.RunCommandContext(ctx, fmt.Sprintf(`%s delete cluster --name %s`, k.path, k.name))
 	if p.Err() != nil {
 		outBytes, err := io.ReadAll(p.Out())
 		if err != nil {
@@ -262,7 +262,7 @@ func (k *Cluster) findOrInstallKind() error {
 }
 
 func (k *Cluster) LoadImage(ctx context.Context, image string, args ...string) error {
-	p := utils.RunCommand(fmt.Sprintf(`%s load docker-image --name %s %s`, k.path, k.name, image))
+	p := utils.RunCommandContext(ctx, fmt.Sprintf(`%s load docker-image --name %s %s`, k.path, k.name, image))
 	if p.Err() != nil {
 		return fmt.Errorf("kind: load docker-image %v failed: %s: %s", image, p.Err(), p.Result())
 	}
@@ -270,7 +270,7 @@ func (k *Cluster) LoadImage(ctx context.Context, image string, args ...string) e
 }
 
 func (k *Cluster) LoadImageArchive(ctx context.Context, imageArchive string, args ...string) error {
-	p := utils.RunCommand(fmt.Sprintf(`%s load image-archive --name %s %s`, k.path, k.name, imageArchive))
+	p := utils.RunCommandContext(ctx, fmt.Sprintf(`%s load image-archive --name %s %s`, k.path, k.name, imageArchive))
 	if p.Err() != nil {
 		return fmt.Errorf("kind: load image-archive %v failed: %s: %s", imageArchive, p.Err(), p.Result())
 	}

--- a/third_party/kwok/kwok.go
+++ b/third_party/kwok/kwok.go
@@ -147,7 +147,7 @@ func (k *Cluster) Create(ctx context.Context, args ...string) (string, error) {
 		command = fmt.Sprintf("%s %s", command, strings.Join(args, " "))
 	}
 	klog.V(4).Info("Launching:", command)
-	p := utils.RunCommand(command)
+	p := utils.RunCommandContext(ctx, command)
 	if p.Err() != nil {
 		outBytes, err := io.ReadAll(p.Out())
 		if err != nil {
@@ -183,7 +183,7 @@ func (k *Cluster) Destroy(ctx context.Context) error {
 		return err
 	}
 
-	p := utils.RunCommand(fmt.Sprintf(`%s delete cluster --name %s`, k.path, k.name))
+	p := utils.RunCommandContext(ctx, fmt.Sprintf(`%s delete cluster --name %s`, k.path, k.name))
 	if p.Err() != nil {
 		outBytes, err := io.ReadAll(p.Out())
 		if err != nil {
@@ -206,15 +206,15 @@ func (k *Cluster) ExportLogs(ctx context.Context, dest string) error {
 	// In kwokctl 0.3.0 and above, there is a new kwokctl export logs feature that has been added which can
 	// simplify the workf of exporting the logs for us. Let us check if the CLI has that command and if so
 	// let us use that to export logs. Otherwise, we can fallback to exporting individual items.
-	p := utils.RunCommand(fmt.Sprintf("%s export logs --help", k.path))
+	p := utils.RunCommandContext(ctx, fmt.Sprintf("%s export logs --help", k.path))
 	if p.ExitCode() == 0 {
-		return utils.RunCommand(fmt.Sprintf("%s --name %s export logs %s", k.path, k.name, dest)).Err()
+		return utils.RunCommandContext(ctx, fmt.Sprintf("%s --name %s export logs %s", k.path, k.name, dest)).Err()
 	}
 
 	// TODO: Get Rid of this if we decide to enforce a min version of the kwokctl at some point
 	for _, component := range []string{"audit", "etcd", "kube-apiserver", "kube-controller-manager", "kube-scheduler", "kwok-controller", "prometheus"} {
 		command := fmt.Sprintf("%s logs %s", k.path, component)
-		p := utils.RunCommand(command)
+		p := utils.RunCommandContext(ctx, command)
 		if p.Err() != nil {
 			klog.ErrorS(p.Err(), "ran into an error trying to export the log", "component", component)
 			continue

--- a/third_party/kwok/kwok.go
+++ b/third_party/kwok/kwok.go
@@ -94,12 +94,12 @@ func (k *Cluster) clusterExists(name string) (string, bool) {
 	return clusters, false
 }
 
-func (k *Cluster) getKubeconfig(args ...string) (string, error) {
+func (k *Cluster) getKubeconfig(ctx context.Context, args ...string) (string, error) {
 	kubecfg := fmt.Sprintf("%s-kubecfg", k.name)
 
 	var stdout, stderr bytes.Buffer
 	cmd := fmt.Sprintf(`%s get kubeconfig %s --name %s`, k.path, strings.Join(args, " "), k.name)
-	err := utils.RunCommandWithSeperatedOutput(cmd, &stdout, &stderr)
+	err := utils.RunCommandWithSeperatedOutputContext(ctx, cmd, &stdout, &stderr)
 	if err != nil {
 		return "", fmt.Errorf("kwokctl get kubeconfig: stderr: %s: %w", stderr.String(), err)
 	}
@@ -135,7 +135,7 @@ func (k *Cluster) Create(ctx context.Context, args ...string) (string, error) {
 	}
 	if _, ok := k.clusterExists(k.name); ok {
 		klog.V(4).Info("Skipping Kwok Cluster creation. Cluster already created ", k.name)
-		kConfig, err := k.getKubeconfig()
+		kConfig, err := k.getKubeconfig(ctx)
 		if err != nil {
 			return "", err
 		}
@@ -162,7 +162,7 @@ func (k *Cluster) Create(ctx context.Context, args ...string) (string, error) {
 	}
 	klog.V(4).Info("kwok cluster available: ", clusters)
 
-	kConfig, err := k.getKubeconfig()
+	kConfig, err := k.getKubeconfig(ctx)
 	if err != nil {
 		return "", err
 	}
@@ -282,5 +282,5 @@ func (k *Cluster) KubernetesRestConfig() *rest.Config {
 }
 
 func (k *Cluster) GenerateKubeconfig(args ...string) (string, error) {
-	return k.getKubeconfig(args...)
+	return k.getKubeconfig(context.Background(), args...)
 }

--- a/third_party/vcluster/vcluster.go
+++ b/third_party/vcluster/vcluster.go
@@ -140,7 +140,7 @@ func (c *Cluster) Create(ctx context.Context, args ...string) (string, error) {
 
 	if _, exists := c.clusterExists(c.name); exists {
 		log.V(4).Info("Skipping vcluster Cluster.Create: cluster already created: ", c.name)
-		kConfig, err := c.getKubeconfig()
+		kConfig, err := c.getKubeconfig(ctx)
 		if err != nil {
 			return "", err
 		}
@@ -179,7 +179,7 @@ func (c *Cluster) Create(ctx context.Context, args ...string) (string, error) {
 	}
 	log.V(4).Info("vcluster clusters available: ", clusters)
 
-	kConfig, err := c.getKubeconfig()
+	kConfig, err := c.getKubeconfig(ctx)
 	if err != nil {
 		return "", err
 	}
@@ -277,7 +277,7 @@ func (c *Cluster) KubernetesRestConfig() *rest.Config {
 }
 
 func (c *Cluster) GenerateKubeconfig(args ...string) (string, error) {
-	return c.getKubeconfig(args...)
+	return c.getKubeconfig(context.Background(), args...)
 }
 
 // helpers to implement support.E2EClusterProvider
@@ -311,12 +311,12 @@ func (c *Cluster) clusterExists(name string) (string, bool) {
 	return raw, false
 }
 
-func (c *Cluster) getKubeconfig(args ...string) (string, error) {
+func (c *Cluster) getKubeconfig(ctx context.Context, args ...string) (string, error) {
 	kubecfg := fmt.Sprintf("%s-kubecfg", c.name)
 
 	var stdout, stderr bytes.Buffer
 	cmd := fmt.Sprintf(`%s connect %s --print %s`, c.path, c.name, strings.Join(args, " "))
-	err := utils.RunCommandWithSeperatedOutput(cmd, &stdout, &stderr)
+	err := utils.RunCommandWithSeperatedOutputContext(ctx, cmd, &stdout, &stderr)
 	if err != nil {
 		return "", fmt.Errorf("vcluster connect: stderr: %s: %w", stderr.String(), err)
 	}

--- a/third_party/vcluster/vcluster.go
+++ b/third_party/vcluster/vcluster.go
@@ -227,7 +227,7 @@ func (c *Cluster) Destroy(ctx context.Context) error {
 	}
 
 	command := fmt.Sprintf("%s delete %s", c.path, c.name)
-	p := utils.RunCommand(command)
+	p := utils.RunCommandContext(ctx, command)
 	if p.Err() != nil {
 		outBytes, err := io.ReadAll(p.Out())
 		if err != nil {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind deprecation


#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
Currently if you cancel the context provided to `provider.Create` most providers ignore the context when running the command to create the cluster. Since cluster creation can be relatively long, it would be ideal if the providers actually forwarded this so the creation can be cancelled.

#### Special notes for your reviewer:

I considered updating existing functions but based on the discussion in #541 it would be preferred to make changes backwards compatible, so I've introduced new context aware functions and marked existing functions that do not takea  context as deprecated.

I also considered updating more code to pass context, but I figured let's keep the scope focused on the `Create()` calls where it arguably matters most.

#### Does this PR introduce a user-facing change?

```release-note
Update third_party cluster providers to propagate context.Context to commands when creating clusters
```