### PR TITLE
feat: allow constructing klient.Client from pre-built controller-runtime client

### DIFF
--- a/klient/client.go
+++ b/klient/client.go
@@ -57,6 +57,17 @@ func New(cfg *rest.Config) (Client, error) {
 	return &client{cfg: cfg, resources: res}, nil
 }
 
+// NewFromCRClient creates a Client backed by an existing controller-runtime
+// client. RESTConfig() returns nil for clients created this way.
+// Useful for unit testing with fake.NewClientBuilder().Build().
+//
+// The provided cr.Client must be goroutine-safe if the returned Client
+// is used with parallel tests (e.g. env.TestInParallel).
+// Clients from fake.NewClientBuilder().Build() satisfy this requirement.
+func NewFromCRClient(cl cr.Client) Client {
+	return &client{resources: resources.NewFromClient(cl)}
+}
+
 // NewWithKubeConfigFile creates a client using the kubeconfig filePath
 func NewWithKubeConfigFile(filePath string) (Client, error) {
 	cfg, err := conf.New(filePath)

--- a/klient/fake_client_test.go
+++ b/klient/fake_client_test.go
@@ -1,0 +1,239 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package klient_test
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	cr "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"sigs.k8s.io/e2e-framework/klient"
+	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
+)
+
+func TestNewFromCRClient_WithFakeClient(t *testing.T) {
+	// Create a fake controller-runtime client
+	fakeClient := fake.NewClientBuilder().
+		WithObjects(&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-cm",
+				Namespace: "default",
+			},
+			Data: map[string]string{
+				"key": "value",
+			},
+		}).
+		Build()
+
+	// Create a klient.Client from the fake client
+	klClient := klient.NewFromCRClient(fakeClient)
+
+	// Test that RESTConfig returns nil
+	if klClient.RESTConfig() != nil {
+		t.Error("expected RESTConfig() to return nil for Client created via NewFromCRClient")
+	}
+
+	// Test that Resources() works and can perform CRUD operations
+	res := klClient.Resources("default")
+
+	// Test Get
+	cm := &corev1.ConfigMap{}
+	err := res.Get(context.TODO(), "test-cm", "default", cm)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if cm.Data["key"] != "value" {
+		t.Errorf("expected data key=value, got %v", cm.Data)
+	}
+
+	// Test Create
+	newCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "new-cm",
+			Namespace: "default",
+		},
+		Data: map[string]string{
+			"newkey": "newvalue",
+		},
+	}
+	err = res.Create(context.TODO(), newCM)
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	// Test Update
+	newCM.Data["newkey"] = "updated"
+	err = res.Update(context.TODO(), newCM)
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+
+	// Verify update
+	updatedCM := &corev1.ConfigMap{}
+	err = res.Get(context.TODO(), "new-cm", "default", updatedCM)
+	if err != nil {
+		t.Fatalf("Get updated ConfigMap failed: %v", err)
+	}
+	if updatedCM.Data["newkey"] != "updated" {
+		t.Errorf("expected newkey=updated, got %v", updatedCM.Data)
+	}
+
+	// Test Delete
+	err = res.Delete(context.TODO(), updatedCM)
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+
+	// Verify deletion
+	deletedCM := &corev1.ConfigMap{}
+	err = res.Get(context.TODO(), "new-cm", "default", deletedCM)
+	if err == nil {
+		t.Error("expected error after delete, but got nil")
+	}
+}
+
+func TestNewFromCRClient_ResourcesWithoutNamespace(t *testing.T) {
+	fakeClient := fake.NewClientBuilder().
+		WithObjects(&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-cm",
+				Namespace: "kube-system",
+			},
+		}).
+		Build()
+
+	klClient := klient.NewFromCRClient(fakeClient)
+
+	// Test Resources() without namespace argument
+	res := klClient.Resources()
+
+	cm := &corev1.ConfigMap{}
+	err := res.Get(context.TODO(), "test-cm", "kube-system", cm)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if cm.Name != "test-cm" {
+		t.Errorf("expected ConfigMap name test-cm, got %s", cm.Name)
+	}
+}
+
+func TestNewFromCRClient_MultipleNamespaces(t *testing.T) {
+	fakeClient := fake.NewClientBuilder().
+		WithObjects(
+			&corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cm1",
+					Namespace: "ns1",
+				},
+			},
+			&corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cm2",
+					Namespace: "ns2",
+				},
+			},
+		).
+		Build()
+
+	klClient := klient.NewFromCRClient(fakeClient)
+
+	// Test with first namespace
+	res1 := klClient.Resources("ns1")
+	cm1 := &corev1.ConfigMap{}
+	err := res1.Get(context.TODO(), "cm1", "ns1", cm1)
+	if err != nil {
+		t.Fatalf("Get from ns1 failed: %v", err)
+	}
+
+	// Test with second namespace
+	res2 := klClient.Resources("ns2")
+	cm2 := &corev1.ConfigMap{}
+	err = res2.Get(context.TODO(), "cm2", "ns2", cm2)
+	if err != nil {
+		t.Fatalf("Get from ns2 failed: %v", err)
+	}
+}
+
+func TestNewFromCRClient_GetConfigReturnsNil(t *testing.T) {
+	fakeClient := fake.NewClientBuilder().Build()
+	klClient := klient.NewFromCRClient(fakeClient)
+
+	if klClient.Resources().GetConfig() != nil {
+		t.Error("expected GetConfig() to return nil for Resources created via NewFromCRClient")
+	}
+}
+
+func TestNewFromCRClient_ExecInPodReturnsError(t *testing.T) {
+	fakeClient := fake.NewClientBuilder().Build()
+	klClient := klient.NewFromCRClient(fakeClient)
+	res := klClient.Resources("default")
+
+	var stdout, stderr bytes.Buffer
+	err := res.ExecInPod(context.TODO(), "default", "test-pod", "container", []string{"echo", "test"}, &stdout, &stderr)
+	if err == nil {
+		t.Fatal("expected ExecInPod to return an error, got nil")
+	}
+	if !strings.Contains(err.Error(), "REST config") {
+		t.Errorf("expected error about REST config, got: %v", err)
+	}
+}
+
+func TestNewFromCRClient_GetControllerRuntimeClient(t *testing.T) {
+	fakeClient := fake.NewClientBuilder().
+		WithObjects(&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-cm",
+				Namespace: "default",
+			},
+		}).
+		Build()
+
+	klClient := klient.NewFromCRClient(fakeClient)
+	crClient := klClient.Resources().GetControllerRuntimeClient()
+	if crClient == nil {
+		t.Fatal("expected GetControllerRuntimeClient() to return non-nil")
+	}
+
+	cm := &corev1.ConfigMap{}
+	err := crClient.Get(context.TODO(), cr.ObjectKey{Name: "test-cm", Namespace: "default"}, cm)
+	if err != nil {
+		t.Fatalf("Get via returned cr.Client failed: %v", err)
+	}
+	if cm.Name != "test-cm" {
+		t.Errorf("expected name test-cm, got %s", cm.Name)
+	}
+}
+
+func TestNewFromCRClient_WatchStartReturnsError(t *testing.T) {
+	fakeClient := fake.NewClientBuilder().Build()
+	res := resources.NewFromClient(fakeClient)
+
+	handler := res.Watch(&corev1.ConfigMapList{})
+	err := handler.Start(context.TODO())
+	if err == nil {
+		t.Fatal("expected Watch.Start to return an error, got nil")
+	}
+	if !strings.Contains(err.Error(), "REST config") {
+		t.Errorf("expected error about REST config, got: %v", err)
+	}
+}

--- a/klient/fake_client_test.go
+++ b/klient/fake_client_test.go
@@ -193,8 +193,8 @@ func TestNewFromCRClient_ExecInPodReturnsError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected ExecInPod to return an error, got nil")
 	}
-	if !strings.Contains(err.Error(), "REST config") {
-		t.Errorf("expected error about REST config, got: %v", err)
+	if !strings.Contains(err.Error(), "is not supported without rest.Config") {
+		t.Errorf("expected error about missing rest.Config, got: %v", err)
 	}
 }
 
@@ -233,7 +233,7 @@ func TestNewFromCRClient_WatchStartReturnsError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected Watch.Start to return an error, got nil")
 	}
-	if !strings.Contains(err.Error(), "REST config") {
-		t.Errorf("expected error about REST config, got: %v", err)
+	if !strings.Contains(err.Error(), "is not supported without rest.Config") {
+		t.Errorf("expected error about missing rest.Config, got: %v", err)
 	}
 }

--- a/klient/k8s/resources/resources.go
+++ b/klient/k8s/resources/resources.go
@@ -78,6 +78,22 @@ func New(cfg *rest.Config) (*Resources, error) {
 	return res, nil
 }
 
+// NewFromClient creates a Resources value backed by an existing
+// controller-runtime client. This is useful for unit testing with
+// fake.NewClientBuilder().Build() where no *rest.Config is available.
+//
+// ExecInPod will return a clear error when config is nil.
+// Watch will succeed, but EventHandlerFuncs.Start() will return an error.
+func NewFromClient(cl cr.Client) *Resources {
+	if cl == nil {
+		panic("NewFromClient: cr.Client must not be nil")
+	}
+	return &Resources{
+		client: cl,
+		scheme: scheme.Scheme,
+	}
+}
+
 // GetConfig hepls to get config type *rest.Config
 func (r *Resources) GetConfig() *rest.Config {
 	return r.config
@@ -293,6 +309,9 @@ func (r *Resources) Watch(object k8s.ObjectList, opts ...ListOption) *watcher.Ev
 }
 
 func (r *Resources) ExecInPod(ctx context.Context, namespaceName, podName, containerName string, command []string, stdout, stderr *bytes.Buffer) error {
+	if r.config == nil {
+		return errors.New("ExecInPod requires a REST config; Resources created via NewFromClient cannot exec in pods")
+	}
 	clientset, err := kubernetes.NewForConfig(r.config)
 	if err != nil {
 		return err

--- a/klient/k8s/resources/resources.go
+++ b/klient/k8s/resources/resources.go
@@ -310,7 +310,7 @@ func (r *Resources) Watch(object k8s.ObjectList, opts ...ListOption) *watcher.Ev
 
 func (r *Resources) ExecInPod(ctx context.Context, namespaceName, podName, containerName string, command []string, stdout, stderr *bytes.Buffer) error {
 	if r.config == nil {
-		return errors.New("ExecInPod requires a REST config; Resources created via NewFromClient cannot exec in pods")
+		return errors.New("the ExecInPod is not supported without rest.Config")
 	}
 	clientset, err := kubernetes.NewForConfig(r.config)
 	if err != nil {

--- a/klient/k8s/watcher/watch.go
+++ b/klient/k8s/watcher/watch.go
@@ -18,6 +18,7 @@ package watcher
 
 import (
 	"context"
+	"errors"
 
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/rest"
@@ -54,6 +55,10 @@ func (e *EventHandlerFuncs) Start(ctx context.Context) error {
 	// check if context is valid and that it has not been cancelled.
 	if ctx.Err() != nil {
 		return ctx.Err()
+	}
+
+	if e.Cfg == nil {
+		return errors.New("Watch requires a REST config; Resources created via NewFromClient cannot watch")
 	}
 
 	cl, err := cr.NewWithWatch(e.Cfg, cr.Options{})

--- a/klient/k8s/watcher/watch.go
+++ b/klient/k8s/watcher/watch.go
@@ -58,7 +58,7 @@ func (e *EventHandlerFuncs) Start(ctx context.Context) error {
 	}
 
 	if e.Cfg == nil {
-		return errors.New("Watch requires a REST config; Resources created via NewFromClient cannot watch")
+		return errors.New("the watch feature is not supported without rest.Config")
 	}
 
 	cl, err := cr.NewWithWatch(e.Cfg, cr.Options{})

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -630,11 +630,17 @@ func (e *testEnv) deepCopyConfig() *envconf.Config {
 	if client := e.cfg.GetClient(); client != nil {
 		// Need to recreate the underlying client because client.Resource is not thread safe
 		// Panic on error because this should never happen since the client was built once already
-		clientCopy, err := klient.New(client.RESTConfig())
-		if err != nil {
-			panic(err)
+		if client.RESTConfig() != nil {
+			clientCopy, err := klient.New(client.RESTConfig())
+			if err != nil {
+				panic(err)
+			}
+			configCopy.WithClient(clientCopy)
+		} else {
+			configCopy.WithClient(klient.NewFromCRClient(
+				client.Resources().GetControllerRuntimeClient(),
+			))
 		}
-		configCopy.WithClient(clientCopy)
 	}
 	if e.cfg.AssessmentRegex() != nil {
 		configCopy.WithAssessmentRegex(e.cfg.AssessmentRegex().String())

--- a/pkg/env/fake_client_test.go
+++ b/pkg/env/fake_client_test.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package env
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"sigs.k8s.io/e2e-framework/klient"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+)
+
+func TestDeepCopyConfig_WithFakeClient(t *testing.T) {
+	// Create a fake controller-runtime client
+	fakeClient := fake.NewClientBuilder().
+		WithObjects(&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-cm",
+				Namespace: "default",
+			},
+		}).
+		Build()
+
+	// Create a klient.Client from the fake client
+	klClient := klient.NewFromCRClient(fakeClient)
+
+	// Create an envconf.Config with the fake-backed client
+	cfg := envconf.New()
+	cfg.WithClient(klClient)
+
+	// Create a test environment with the config
+	testEnv := NewWithConfig(cfg)
+
+	// Create a simple feature to trigger deepCopyConfig via processTests
+	// This will create a child environment which calls deepCopyConfig
+	// and should not panic even though the client has a nil RESTConfig
+	feature := features.New("test feature").
+		Assess("test assessment", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			// Verify the client is still available
+			if cfg.Client() == nil {
+				t.Error("expected client to be available in copied config")
+			}
+			return ctx
+		}).
+		Feature()
+
+	// This will trigger deepCopyConfig internally
+	testEnv.Test(t, feature)
+}
+
+func TestDeepCopyConfig_WithFakeClientAndNamespace(t *testing.T) {
+	// Create a fake controller-runtime client
+	fakeClient := fake.NewClientBuilder().
+		WithObjects(&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-cm",
+				Namespace: "test-ns",
+			},
+		}).
+		Build()
+
+	// Create a klient.Client from the fake client
+	klClient := klient.NewFromCRClient(fakeClient)
+
+	// Create an envconf.Config with the fake-backed client and a namespace
+	cfg := envconf.New()
+	cfg.WithClient(klClient)
+	cfg.WithNamespace("test-ns")
+
+	// Create a test environment with the config
+	testEnv := NewWithConfig(cfg)
+
+	// Create a feature to trigger deepCopyConfig
+	feature := features.New("test feature with namespace").
+		Assess("test assessment", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			// Verify the namespace is preserved in the copied config
+			if cfg.Namespace() != "test-ns" {
+				t.Errorf("expected namespace test-ns, got %s", cfg.Namespace())
+			}
+			// Verify the client is still available
+			if cfg.Client() == nil {
+				t.Error("expected client to be available in copied config")
+			}
+			return ctx
+		}).
+		Feature()
+
+	// This will trigger deepCopyConfig internally
+	testEnv.Test(t, feature)
+}


### PR DESCRIPTION
## Changes

Add `NewFromClient` and `NewFromCRClient` constructors to build `klient.Client` and `Resources` from an existing `cr.Client` without requiring a `*rest.Config` or live API server. This enables unit testing of code that accepts `env.Environment`, `*envconf.Config`, or `klient.Client` with `fake.NewClientBuilder().Build()`.

### New API

```go
// klient/k8s/resources
func NewFromClient(cl cr.Client) *Resources

// klient
func NewFromCRClient(cl cr.Client) Client
```

### Usage

```go
fakeClient := fake.NewClientBuilder().WithObjects(myObj).Build()
cfg := envconf.New().WithClient(klient.NewFromCRClient(fakeClient))
testenv := env.NewWithConfig(cfg)

testenv.Setup(func(ctx context.Context, cfg *envconf.Config) (context.Context, error) {
    // cfg.Client().Resources().Get(...) works against the fake
    return ctx, nil
})
```

### Guards for methods requiring *rest.Config

- `ExecInPod` returns a clear error when config is nil.
- `Watch` succeeds, but `EventHandlerFuncs.Start()` returns a clear error.
- `NewFromClient(nil)` panics (programmer error, matching framework style).

### deepCopyConfig fix

`deepCopyConfig()` in `pkg/env/env.go` now handles nil `RESTConfig()` by using the `NewFromCRClient` path instead of panicking.

### Tests

- 7 unit tests for `NewFromCRClient` covering CRUD, nil RESTConfig, nil GetConfig, ExecInPod error, Watch.Start error, GetControllerRuntimeClient, and multi-namespace usage.
- 2 unit tests for `deepCopyConfig` with fake client (via `env.Test` which triggers `deepCopyConfig` internally).

All changes are additive. Existing constructors and behavior are unchanged.

Closes #588

Assisted-by: 🤖 claude-opus-4-6@default